### PR TITLE
Spritesheets and Slice9 implementations

### DIFF
--- a/haxe/ui/backend/AssetsBase.hx
+++ b/haxe/ui/backend/AssetsBase.hx
@@ -5,6 +5,9 @@ import flash.display.Loader;
 import flash.events.Event;
 import flash.utils.ByteArray;
 import flixel.graphics.FlxGraphic;
+import flixel.graphics.frames.FlxFrame;
+import flixel.graphics.frames.FlxFramesCollection;
+import flixel.graphics.frames.FlxImageFrame;
 import haxe.ui.assets.FontInfo;
 import haxe.ui.assets.ImageInfo;
 import haxe.ui.util.ByteConverter;
@@ -12,24 +15,40 @@ import openfl.Assets;
 
 class AssetsBase {
 
+	var frames(get, never):FlxFramesCollection;
+	
+	function get_frames():FlxFramesCollection {
+		if (Toolkit.assets.options != null && Toolkit.assets.options.spritesheet != null) return Toolkit.assets.options.spritesheet;
+		return null;
+	}
+	
     public function new() {
 		
     }
-
+	
     function getImageInternal(resourceId:String, callback:ImageInfo->Void):Void {
 		
-		if (!Assets.exists(resourceId)) {
-			callback(null);
-			return;
+		var graphic:FlxGraphic = null;
+		var frame:FlxFrame = null;
+		
+		if (Assets.exists(resourceId)) {
+			graphic = FlxGraphic.fromAssetKey(resourceId);
 		}
 		
-		var graphic = FlxGraphic.fromAssetKey(resourceId);
+		if (graphic == null) {
+			var fr = frames;
+			if (fr != null && fr.framesHash.exists(resourceId)) frame = fr.getByName(resourceId);
+		}
 		
-		if (graphic != null) callback( { data : graphic, width : graphic.width, height : graphic.height } );
+		else {
+			frame = FlxImageFrame.fromGraphic(graphic).frame;
+		}
+		
+		if (frame != null) callback( { data : frame, width : Std.int(frame.sourceSize.x), height : Std.int(frame.sourceSize.y) } );
 		else callback(null);
     }
 
-    function getImageFromHaxeResource(resourceId:String, callback:String->ImageInfo->Void) {
+    function getImageFromHaxeResource(resourceId:String, callback:String->ImageInfo->Void):Void {
         
 		var bytes = Resource.getBytes(resourceId);
         var ba:ByteArray = ByteConverter.fromHaxeBytes(bytes);
@@ -39,8 +58,8 @@ class AssetsBase {
         loader.contentLoaderInfo.addEventListener(Event.COMPLETE, function(e) {
 			
             if (loader.content != null) {
-                var graphic = FlxGraphic.fromBitmapData(cast(loader.content, Bitmap).bitmapData);
-                callback(resourceId, { data : graphic, width : graphic.width, height : graphic.height } );
+                var frame = FlxImageFrame.fromGraphic(FlxGraphic.fromBitmapData(cast(loader.content, Bitmap).bitmapData)).frame;
+                callback(resourceId, { data : frame, width : Std.int(frame.sourceSize.x), height : Std.int(frame.sourceSize.y) } );
             }
         });
 		
@@ -51,12 +70,12 @@ class AssetsBase {
         callback(null);
     }
 
-    function getFontFromHaxeResource(resourceId:String, callback:String->FontInfo->Void) {
+    function getFontFromHaxeResource(resourceId:String, callback:String->FontInfo->Void):Void {
         callback(resourceId, null);
     }
 
     function getTextDelegate(resourceId:String):String {
-        
+		
 		if (Assets.exists(resourceId)) {
 			return Assets.getText(resourceId);
 		}

--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -138,7 +138,7 @@ class ComponentBase extends FlxSpriteGroup implements IComponentBase {
     function mapEvent(type:String, listener:UIEvent->Void) {
 		
 		if (!__mouseRegistered) {
-			FlxMouseEventManager.add(this);
+			FlxMouseEventManager.add(this, null, null, null, null, true);
 			__mouseRegistered = true;
 		}
 		

--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -28,6 +28,7 @@ class ComponentBase extends FlxSpriteGroup implements IComponentBase {
 		super();
 		
 		surface = new FlxSprite();
+		surface.makeGraphic(1, 1, 0x0, true);
 		add(surface);
     }
 	

--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -1,12 +1,10 @@
 package haxe.ui.backend;
 
-import flash.geom.Point;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.group.FlxSpriteGroup;
 import flixel.input.mouse.FlxMouseEventManager;
 import flixel.math.FlxRect;
-import haxe.ui.assets.ImageInfo;
 import haxe.ui.backend.flixel.FlxStyleHelper;
 import haxe.ui.core.Component;
 import haxe.ui.core.IComponentBase;
@@ -116,16 +114,7 @@ class ComponentBase extends FlxSpriteGroup implements IComponentBase {
 
     function handleClipRect(value:Rectangle):Void {
 		if (value == null) clipRect = null;
-		
-		else {
-			
-			if (dirty) {
-				x = asComponent.screenLeft;
-				y = asComponent.screenTop;
-			}
-			
-			clipRect = FlxRect.get(value.left, value.top, value.width, value.height);
-		}
+		else clipRect = FlxRect.get(value.left, value.top, value.width, value.height);
     }
 
     function handlePosition(left:Null<Float>, top:Null<Float>, style:Style):Void {

--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -118,8 +118,8 @@ class ComponentBase extends FlxSpriteGroup implements IComponentBase {
     }
 
     function handlePosition(left:Null<Float>, top:Null<Float>, style:Style):Void {
-		
-		// applyStyle(style);
+		asComponent.left = left;
+		asComponent.top = top;
     }
 
     function handlePreReposition() {

--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -109,12 +109,23 @@ class ComponentBase extends FlxSpriteGroup implements IComponentBase {
 		
 		surface.makeGraphic(Std.int(width), Std.int(height), 0x0, true);
 		
+		if (clipRect != null) surface.clipRect = clipRect;
+		
 		applyStyle(style);
     }
 
     function handleClipRect(value:Rectangle):Void {
-		//if (value == null) clipRect = null;
-		//else clipRect = FlxRect.get(value.left, value.top, value.width, value.height);
+		if (value == null) clipRect = null;
+		
+		else {
+			
+			if (dirty) {
+				x = asComponent.screenLeft;
+				y = asComponent.screenTop;
+			}
+			
+			clipRect = FlxRect.get(value.left, value.top, value.width, value.height);
+		}
     }
 
     function handlePosition(left:Null<Float>, top:Null<Float>, style:Style):Void {

--- a/haxe/ui/backend/ImageData.hx
+++ b/haxe/ui/backend/ImageData.hx
@@ -1,3 +1,3 @@
 package haxe.ui.backend;
 
-typedef ImageData = flixel.graphics.FlxGraphic;
+typedef ImageData = flixel.graphics.frames.FlxFrame;

--- a/haxe/ui/backend/ImageDisplayBase.hx
+++ b/haxe/ui/backend/ImageDisplayBase.hx
@@ -40,7 +40,7 @@ class ImageDisplayBase extends FlxSprite {
 		imageInfo = value;
         aspectRatio = value.width / value.height;
 		
-		loadGraphic(value.data);
+		frame = value.data;
 		
         return value;
     }

--- a/haxe/ui/backend/ScreenBase.hx
+++ b/haxe/ui/backend/ScreenBase.hx
@@ -48,7 +48,16 @@ class ScreenBase {
         container.group.insert(index, child);
     }
 
-    var container(default, null):FlxSpriteGroup;
+    var container(get, null):FlxSpriteGroup;
+	
+	function get_container():FlxSpriteGroup {
+		
+		if (options != null && options.container != null) {
+			return options.container;
+		}
+		
+		throw "Please set a FlxSpriteGroup as the container when initializing the Toolkit: Toolkit.init( { container : fsg } );";
+	}
 
     function mapEvent(type:String, listener:UIEvent->Void) {
 		

--- a/haxe/ui/backend/TextDisplayBase.hx
+++ b/haxe/ui/backend/TextDisplayBase.hx
@@ -41,8 +41,23 @@ class TextDisplayBase extends FlxText {
 	
     public var textAlign:String;
 	
-	override function set_clipRect(value:FlxRect):FlxRect {
-		return super.set_clipRect(value);
+	override function set_text(Text:String):String {
+		
+		var tempRect = clipRect;
+		
+		super.set_text(Text);
+		
+		clipRect = tempRect;
+		
+		return Text;
+	}
+	
+	override function set_clipRect(rect:FlxRect):FlxRect {
+		
+		if (rect != null) 
+			regenGraphic();
+		
+		return super.set_clipRect(rect);
 	}
 	
 	override public function draw():Void {

--- a/haxe/ui/backend/TextDisplayBase.hx
+++ b/haxe/ui/backend/TextDisplayBase.hx
@@ -33,9 +33,7 @@ class TextDisplayBase extends FlxText {
         return value;
     }
 	
-	inline function isEmbeddedFont(name:String):Bool {
-        return (name != "_sans" && name != "_serif" && name != "_typewriter");
-    }
+	
 
     public var fontSize(get, set):Null<Float>;
     inline function get_fontSize():Null<Float> { return size; }
@@ -46,6 +44,25 @@ class TextDisplayBase extends FlxText {
 	
 	public function applyStyle(style:Style):Void {
 		
+		// color, bold, italics, underline, etc
+		
+		if (style.width != null) {
+			autoSize = false;
+			fieldWidth = style.width;
+		}
+		
+		if (style.fontName != null) {
+			if (isEmbeddedFont(style.fontName)) font = style.fontName;
+			else systemFont = style.fontName;
+		}
+		
+		if (style.fontSize != null) {
+			size = Std.int(style.fontSize);
+		}
+		
+		if (style.textAlign != null) {
+			alignment = style.textAlign;
+		}
 	}
 	
 	override function set_text(Text:String):String {
@@ -76,4 +93,8 @@ class TextDisplayBase extends FlxText {
 		
 		super.draw();
 	}
+	
+	inline function isEmbeddedFont(name:String):Bool {
+        return name != "_sans" && name != "_serif" && name != "_typewriter";
+    }
 }

--- a/haxe/ui/backend/TextDisplayBase.hx
+++ b/haxe/ui/backend/TextDisplayBase.hx
@@ -3,6 +3,7 @@ package haxe.ui.backend;
 import flixel.math.FlxRect;
 import flixel.text.FlxText;
 import haxe.ui.core.Component;
+import haxe.ui.styles.Style;
 
 class TextDisplayBase extends FlxText {
 	
@@ -21,6 +22,7 @@ class TextDisplayBase extends FlxText {
     public var textHeight(get, null):Float;
     inline function get_textHeight():Float { return textField.textHeight + 4; }
 
+	/*
     public var fontName(get, set):String;
     inline function get_fontName():String { return embedded ? font : systemFont; }
     inline function set_fontName(value:String):String {
@@ -40,6 +42,11 @@ class TextDisplayBase extends FlxText {
     inline function set_fontSize(value:Null<Float>):Null<Float> { return size = Std.int(value); }
 	
     public var textAlign:String;
+	*/
+	
+	public function applyStyle(style:Style):Void {
+		
+	}
 	
 	override function set_text(Text:String):String {
 		

--- a/haxe/ui/backend/flixel/FlxStyleHelper.hx
+++ b/haxe/ui/backend/flixel/FlxStyleHelper.hx
@@ -44,7 +44,7 @@ class FlxStyleHelper{
 	
 	static function drawBG(sprite:FlxSprite, data:ImageData, style:Style):Void {
 		
-		var bmd = data.bitmap;
+		var bmd = data.parent.bitmap;
 		var rect = bmd.rect;
 		
 		// 9slice

--- a/haxe/ui/backend/flixel/FlxStyleHelper.hx
+++ b/haxe/ui/backend/flixel/FlxStyleHelper.hx
@@ -8,6 +8,7 @@ import flixel.util.FlxSpriteUtil;
 import haxe.ui.assets.ImageInfo;
 import haxe.ui.backend.ImageData;
 import haxe.ui.styles.Style;
+import haxe.ui.util.Slice9;
 
 /**
  * ...
@@ -45,50 +46,138 @@ class FlxStyleHelper{
 	static function drawBG(sprite:FlxSprite, data:ImageData, style:Style):Void {
 		
 		var bmd = data.parent.bitmap;
-		var rect = bmd.rect;
-		
-		// 9slice
+		var rect = data.frame.copyToFlash();
 		
 		if (style.backgroundImageClipTop != null && style.backgroundImageClipBottom != null && style.backgroundImageClipLeft != null && style.backgroundImageClipRight != null) {
-			rect = new Rectangle(style.backgroundImageClipLeft, style.backgroundImageClipTop, style.backgroundImageClipRight - style.backgroundImageClipLeft, style.backgroundImageClipBottom - style.backgroundImageClipTop);
+			rect.x += style.backgroundImageClipLeft;
+			rect.y += style.backgroundImageClipTop;
+			rect.width = Math.min(rect.width, style.backgroundImageClipRight - style.backgroundImageClipLeft);
+			rect.height = Math.min(rect.height, style.backgroundImageClipBottom - style.backgroundImageClipTop);
 		}
 		
-		var matrix:Matrix = null;
+		var slice:haxe.ui.util.Rectangle = null;
 		
-		if (style.backgroundImageRepeat == "stretch") {
-			matrix = new Matrix();
-			matrix.scale(sprite.frameWidth / rect.width, sprite.frameHeight / rect.height);
+		if (style.backgroundImageSliceTop != null && style.backgroundImageSliceBottom != null && style.backgroundImageSliceLeft != null && style.backgroundImageSliceRight != null) {
+			slice = new haxe.ui.util.Rectangle(style.backgroundImageSliceLeft, style.backgroundImageSliceTop, style.backgroundImageSliceRight - style.backgroundImageSliceLeft, style.backgroundImageSliceBottom - style.backgroundImageSliceTop);
 		}
 		
-		if (matrix == null) {
+		if (slice == null) {
 			
-			var blitPt = new Point();
+			var matrix:Matrix = null;
 			
-			if (style.backgroundImageRepeat == null) {
-				sprite.pixels.copyPixels(bmd, rect, blitPt);
+			if (style.backgroundImageRepeat == "stretch") {
+				matrix = new Matrix();
+				matrix.translate( -rect.x, -rect.y);
+				matrix.scale(sprite.frameWidth / rect.width, sprite.frameHeight / rect.height);
 			}
 			
-			else if (style.backgroundImageRepeat == "repeat") {
+			if (matrix == null) {
 				
-				var repX = Math.ceil(sprite.frameWidth / rect.width);
-				var repY = Math.ceil(sprite.frameHeight / rect.height);
+				var blitPt = new Point();
 				
-				for (i in 0...repX) {
+				if (style.backgroundImageRepeat == null) {
+					sprite.pixels.copyPixels(bmd, rect, blitPt);
+				}
+				
+				else if (style.backgroundImageRepeat == "repeat") {
 					
-					blitPt.x = i * rect.width;
+					var repX = Math.ceil(sprite.frameWidth / rect.width);
+					var repY = Math.ceil(sprite.frameHeight / rect.height);
 					
-					for (j in 0...repY) {
+					for (i in 0...repX) {
 						
-						blitPt.y = j * rect.height;
+						blitPt.x = i * rect.width;
 						
-						sprite.pixels.copyPixels(bmd, rect, blitPt);
+						for (j in 0...repY) {
+							
+							blitPt.y = j * rect.height;
+							
+							sprite.pixels.copyPixels(bmd, rect, blitPt);
+						}
 					}
 				}
+			}
+			
+			else {
+				sprite.pixels.draw(bmd, matrix, null, null, null);
 			}
 		}
 		
 		else {
-			sprite.pixels.draw(bmd, matrix, null, null, rect == bmd.rect ? null : rect);
+			
+			var rects = Slice9.buildRects(sprite.frameWidth, sprite.frameHeight, rect.width, rect.height, slice);
+			
+			var src = null;
+			for (i in 0...rects.src.length) {
+				
+				src = rects.src[i];
+				
+				src.left += rect.x;
+				src.top += rect.y;
+			}
+			
+			var srcOpenFL = new Rectangle();
+			var dstOpenFL = new Rectangle();
+			var dstPt = new Point();
+			var mat = new Matrix();
+			
+			var pixels = sprite.pixels;
+			
+			// 9-slice credit @MSGhero and @IBwWG: https://gist.github.com/IBwWG/9ffe25a059983e7e4eeb7640d6645a37
+			
+			// copyPx() the corners
+			pixels.copyPixels(bmd, setOpenFLRect(srcOpenFL, rects.src[0]), setOpenFLRect(dstOpenFL, rects.dst[0]).topLeft, null, null, true); // TL
+			pixels.copyPixels(bmd, setOpenFLRect(srcOpenFL, rects.src[2]), setOpenFLRect(dstOpenFL, rects.dst[2]).topLeft, null, null, true); // TR
+			pixels.copyPixels(bmd, setOpenFLRect(srcOpenFL, rects.src[6]), setOpenFLRect(dstOpenFL, rects.dst[6]).topLeft, null, null, true); // BL
+			pixels.copyPixels(bmd, setOpenFLRect(srcOpenFL, rects.src[8]), setOpenFLRect(dstOpenFL, rects.dst[8]).topLeft, null, null, true); // BR
+			
+			// draw() the sides and center
+			var tl = rects.src[0];
+			var center = rects.src[4];
+			var br = rects.src[8];
+			
+			var scaleH = rects.dst[4].width / center.width;
+			var scaleV = rects.dst[4].height / center.height;
+			
+			// is it better to draw() from bmd (scaling a large bmd) or from a temp copyPx slice (creates a new bmd each time)?
+			
+			setOpenFLRect(dstOpenFL, rects.dst[1]);
+			mat.translate(tl.width * (1 / scaleH - 1) - rect.x, -rect.y);
+			mat.scale(scaleH, 1);
+			pixels.draw(bmd, mat, null, null, dstOpenFL); // T
+			
+			mat.identity();
+			
+			setOpenFLRect(dstOpenFL, rects.dst[3]);
+			mat.translate( -rect.x, tl.height * (1 / scaleV - 1) - rect.y);
+			mat.scale(1, scaleV);
+			pixels.draw(bmd, mat, null, null, dstOpenFL); // L
+			
+			mat.identity();
+			
+			setOpenFLRect(dstOpenFL, rects.dst[4]);
+			mat.translate(tl.width * (1 / scaleH - 1) - rect.x, tl.height * (1 / scaleV - 1) - rect.y);
+			mat.scale(scaleH, scaleV);
+			pixels.draw(bmd, mat, null, null, dstOpenFL); // C
+			
+			mat.identity();
+			
+			setOpenFLRect(dstOpenFL, rects.dst[5]);
+			mat.translate(sprite.frameWidth - rect.width - rect.x, tl.height * (1 / scaleV - 1) - rect.y);
+			mat.scale(1, scaleV);
+			pixels.draw(bmd, mat, null, null, dstOpenFL); // R
+			
+			mat.identity();
+			
+			setOpenFLRect(dstOpenFL, rects.dst[7]);
+			mat.translate(tl.width * (1 / scaleH - 1) - rect.x, sprite.frameHeight - rect.height - rect.y);
+			mat.scale(scaleH, 1);
+			pixels.draw(bmd, mat, null, null, dstOpenFL); // B
 		}
+	}
+	
+	static function setOpenFLRect(oflRect:flash.geom.Rectangle, uiRect:haxe.ui.util.Rectangle):flash.geom.Rectangle {
+		oflRect.setTo(uiRect.left, uiRect.top, uiRect.width, uiRect.height);
+		return oflRect;
 	}
 }


### PR DESCRIPTION
Spritesheets are now valid sources when looking for assets. E.g.: the `FlxAtlasFrames` output of loading a TexturePacker .png and .json can be registered and used as a source of images.

Added some clip rect changes, but these may need to be changed in Flixel itself instead of just here.