### PR TITLE
Implement keyboard events for components

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -7,6 +7,7 @@ import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import haxe.ui.Toolkit;
 import haxe.ui.backend.flixel.CursorHelper;
+import haxe.ui.backend.flixel.KeyboardHelper;
 import haxe.ui.backend.flixel.MouseHelper;
 import haxe.ui.backend.flixel.StateHelper;
 import haxe.ui.core.Component;
@@ -301,13 +302,13 @@ class ScreenImpl extends ScreenBase {
             case KeyboardEvent.KEY_DOWN:
                 if (_mapping.exists(type) == false) {
                     _mapping.set(type, listener);
-                    FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_DOWN, __onKeyEvent);
+                    KeyboardHelper.notify(KeyboardEvent.KEY_DOWN, __onKeyEvent, 10);
                 }
 
             case KeyboardEvent.KEY_UP:
                 if (_mapping.exists(type) == false) {
                     _mapping.set(type, listener);
-                    FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_UP, __onKeyEvent);
+                    KeyboardHelper.notify(KeyboardEvent.KEY_UP, __onKeyEvent, 10);
                 }
         }
     }
@@ -372,23 +373,16 @@ class ScreenImpl extends ScreenBase {
         }
     }
 
-    private function __onKeyEvent(event:openfl.events.KeyboardEvent) {
-        var type:String = null;
-        if (event.type == openfl.events.KeyboardEvent.KEY_DOWN) {
-            type = KeyboardEvent.KEY_DOWN;
-        } else if (event.type == openfl.events.KeyboardEvent.KEY_UP) {
-            type = KeyboardEvent.KEY_UP;
-        }
-
-        if (type != null) {
-            var fn = _mapping.get(type);
-            if (fn != null) {
-                var keyboardEvent = new KeyboardEvent(type);
-                keyboardEvent.keyCode = event.keyCode;
-                keyboardEvent.ctrlKey = event.ctrlKey;
-                keyboardEvent.shiftKey = event.shiftKey;
-                fn(keyboardEvent);
-            }
+    private function __onKeyEvent(event:KeyboardEvent) {
+        var fn = _mapping.get(event.type);
+        if (fn != null) {
+            var keyboardEvent = new KeyboardEvent(event.type);
+            keyboardEvent.keyCode = event.keyCode;
+            keyboardEvent.altKey = event.altKey;
+            keyboardEvent.ctrlKey = event.ctrlKey;
+            keyboardEvent.shiftKey = event.shiftKey;
+            fn(keyboardEvent);
+            event.canceled = keyboardEvent.canceled;
         }
     }
 

--- a/haxe/ui/backend/flixel/KeyboardHelper.hx
+++ b/haxe/ui/backend/flixel/KeyboardHelper.hx
@@ -1,0 +1,125 @@
+package haxe.ui.backend.flixel;
+
+import flixel.FlxG;
+import haxe.ui.events.KeyboardEvent;
+
+typedef KeyboardCallback = {
+    var fn:KeyboardEvent->Void;
+    var priority:Int;
+}
+
+class KeyboardHelper {
+    private static var _hasOnKeyDown:Bool = false;
+    private static var _hasOnKeyUp:Bool = false;
+
+    private static var _callbacks:Map<String, Array<KeyboardCallback>> = new Map<String, Array<KeyboardCallback>>();
+    
+    public static function notify(event:String, callback:KeyboardEvent->Void, priority:Int = 5) {
+        switch (event) {
+            case KeyboardEvent.KEY_DOWN:
+                if (_hasOnKeyDown == false) {
+                    FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_DOWN, onKeyDown);
+                    _hasOnKeyDown = true;
+                }
+            case KeyboardEvent.KEY_UP:
+                if (_hasOnKeyUp == false) {
+                    FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_UP, onKeyUp);
+                    _hasOnKeyUp = true;
+                }
+        }
+
+        var list = _callbacks.get(event);
+        if (list == null) {
+            list = new Array<KeyboardCallback>();
+            _callbacks.set(event, list);
+        }
+        
+        if (!hasCallback(list, callback)) {
+            list.insert(0, {
+                fn: callback,
+                priority: priority
+            });
+
+            list.sort(function(a, b) {
+                return a.priority - b.priority;
+            });
+        }
+    }
+
+    public static function remove(event:String, callback:KeyboardEvent->Void) {
+        var list = _callbacks.get(event);
+        if (list != null) {
+            removeCallback(list, callback);
+            if (list.length == 0) {
+                _callbacks.remove(event);
+                
+                switch (event) {
+                    case KeyboardEvent.KEY_DOWN:
+                        if (_hasOnKeyDown == true) {
+                            FlxG.stage.removeEventListener(openfl.events.KeyboardEvent.KEY_DOWN, onKeyDown);
+                            _hasOnKeyDown = false;
+                        }
+                    case KeyboardEvent.KEY_UP:
+                        if (_hasOnKeyUp == true) {
+                            FlxG.stage.removeEventListener(openfl.events.KeyboardEvent.KEY_UP, onKeyUp);
+                            _hasOnKeyUp = false;
+                        }
+                }
+            }
+        }
+    }
+
+    private static function onKeyDown(e:openfl.events.KeyboardEvent) {
+        dispatchEvent(KeyboardEvent.KEY_DOWN, e);
+    }
+
+    private static function onKeyUp(e:openfl.events.KeyboardEvent) {
+        dispatchEvent(KeyboardEvent.KEY_UP, e);
+    }
+
+    private static function dispatchEvent(type:String, e:openfl.events.KeyboardEvent) {
+        var list = _callbacks.get(type);
+        if (list == null || list.length == 0) {
+            return;
+        }
+        
+        list = list.copy();
+
+        var event = new KeyboardEvent(type);
+        event.keyCode = e.keyCode;
+        event.altKey = e.altKey;
+        event.ctrlKey = e.ctrlKey;
+        event.shiftKey = e.shiftKey;
+
+        for (l in list) {
+            l.fn(event);
+            if (event.canceled == true) {
+                break;
+            }
+        }
+    }
+
+    private static function hasCallback(list:Array<KeyboardCallback>, fn:KeyboardEvent->Void):Bool {
+        var has = false;
+        for (item in list) {
+            if (item.fn == fn) {
+                has = true;
+                break;
+            }
+        }
+        return has;
+    }
+
+    private static function removeCallback(list:Array<KeyboardCallback>, fn:KeyboardEvent->Void) {
+        var itemToRemove:KeyboardCallback = null;
+        for (item in list) {
+            if (item.fn == fn) {
+                itemToRemove = item;
+                break;
+            }
+        }
+        if (itemToRemove != null) {
+            list.remove(itemToRemove);
+        }
+    }
+}

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -3,7 +3,7 @@ package haxe.ui.backend.flixel;
 import flixel.FlxG;
 import haxe.ui.events.MouseEvent;
 
-typedef Callback = {
+typedef MouseCallback = {
     var fn:MouseEvent->Void;
     var priority:Int;
 }
@@ -17,7 +17,7 @@ class MouseHelper {
     private static var _hasOnMouseMove:Bool = false;
     private static var _hasOnMouseWheel:Bool = false;
     
-    private static var _callbacks:Map<String, Array<Callback>> = new Map<String, Array<Callback>>();
+    private static var _callbacks:Map<String, Array<MouseCallback>> = new Map<String, Array<MouseCallback>>();
     
     public static function notify(event:String, callback:MouseEvent->Void, priority:Int = 5) {
         switch (event) {
@@ -48,7 +48,7 @@ class MouseHelper {
         
         var list = _callbacks.get(event);
         if (list == null) {
-            list = new Array<Callback>();
+            list = new Array<MouseCallback>();
             _callbacks.set(event, list);
         }
         
@@ -248,7 +248,7 @@ class MouseHelper {
         #end
     }
     
-    private static function hasCallback(list:Array<Callback>, fn:MouseEvent->Void):Bool {
+    private static function hasCallback(list:Array<MouseCallback>, fn:MouseEvent->Void):Bool {
         var has = false;
         for (item in list) {
             if (item.fn == fn) {
@@ -259,8 +259,8 @@ class MouseHelper {
         return has;
     }
     
-    private static function removeCallback(list:Array<Callback>, fn:MouseEvent->Void) {
-        var itemToRemove:Callback = null;
+    private static function removeCallback(list:Array<MouseCallback>, fn:MouseEvent->Void) {
+        var itemToRemove:MouseCallback = null;
         for (item in list) {
             if (item.fn == fn) {
                 itemToRemove = item;

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -4,6 +4,7 @@ import flixel.FlxSprite;
 import haxe.ui.backend.TextInputImpl.TextInputEvent;
 import haxe.ui.core.Component;
 import openfl.events.Event;
+import openfl.events.KeyboardEvent;
 
 #if flixel_text_input
 
@@ -308,6 +309,42 @@ class FlxTextInput extends TextBase {
                 stageY: 0
             });
         }
+    }
+
+    private var _onKeyDown:KeyboardEvent->Void = null;
+    public var onKeyDown(null, set):KeyboardEvent->Void;
+    private function set_onKeyDown(value:KeyboardEvent->Void):KeyboardEvent->Void {
+        if (_onKeyDown != null) {
+            tf.textField.removeEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
+        }
+        _onKeyDown = value;
+        if (_onKeyDown != null) {
+            tf.textField.addEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
+        }
+        return value;
+    }
+
+    private function __onTextInputKeyDown(e:KeyboardEvent) {
+        if (_onKeyDown != null)
+            _onKeyDown(e);
+    }
+
+    private var _onKeyUp:KeyboardEvent->Void = null;
+    public var onKeyUp(null, set):KeyboardEvent->Void;
+    private function set_onKeyUp(value:KeyboardEvent->Void):KeyboardEvent->Void {
+        if (_onKeyUp != null) {
+            tf.textField.removeEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
+        }
+        _onKeyUp = value;
+        if (_onKeyUp != null) {
+            tf.textField.addEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
+        }
+        return value;
+    }
+
+    private function __onTextInputKeyUp(e:KeyboardEvent) {
+        if (_onKeyUp != null)
+            _onKeyUp(e);
     }
 
     private function onInternalChange() {

--- a/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
@@ -9,6 +9,7 @@ import haxe.ui.core.Screen;
 import haxe.ui.events.UIEvent;
 import haxe.ui.geom.Rectangle;
 import openfl.events.Event;
+import openfl.events.KeyboardEvent;
 import openfl.text.TextField;
 import openfl.text.TextFieldAutoSize;
 import openfl.text.TextFieldType;
@@ -197,6 +198,42 @@ class OpenFLTextInput extends TextBase {
                 stageY: 0
             });
         }
+    }
+
+    private var _onKeyDown:KeyboardEvent->Void = null;
+    public var onKeyDown(null, set):KeyboardEvent->Void;
+    private function set_onKeyDown(value:KeyboardEvent->Void):KeyboardEvent->Void {
+        if (_onKeyDown != null) {
+            tf.removeEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
+        }
+        _onKeyDown = value;
+        if (_onKeyDown != null) {
+            tf.addEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
+        }
+        return value;
+    }
+
+    private function __onTextInputKeyDown(e:KeyboardEvent) {
+        if (_onKeyDown != null)
+            _onKeyDown(e);
+    }
+
+    private var _onKeyUp:KeyboardEvent->Void = null;
+    public var onKeyUp(null, set):KeyboardEvent->Void;
+    private function set_onKeyUp(value:KeyboardEvent->Void):KeyboardEvent->Void {
+        if (_onKeyUp != null) {
+            tf.removeEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
+        }
+        _onKeyUp = value;
+        if (_onKeyUp != null) {
+            tf.addEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
+        }
+        return value;
+    }
+
+    private function __onTextInputKeyUp(e:KeyboardEvent) {
+        if (_onKeyUp != null)
+            _onKeyUp(e);
     }
 
     public function addToComponent(component:Component) {


### PR DESCRIPTION
This allows components to dispatch KEY_DOWN and KEY_UP events. Tested with HTML5 and C++ on Windows.

Other changes this pull request makes:
- `onKeyDown` and `onKeyUp` variables added for the text input classes, required for detecting when a key is pressed or released while a text input has focus, since the event only dispatches to the text input instead of the stage
- `Callback` class in `MouseHelper` is renamed to `MouseCallback`, since there is now also a callback class in `KeyboardHelper`

Demonstration with the "Todos" example from the component explorer:

https://github.com/haxeui/haxeui-flixel/assets/85134252/6b77ee3f-8c2d-42c7-8ab8-cb73f595b3c1

