### PR TITLE
Fixes for text objects (mostly text input)

### DIFF
--- a/haxe/ui/backend/TextDisplayImpl.hx
+++ b/haxe/ui/backend/TextDisplayImpl.hx
@@ -12,7 +12,7 @@ class TextDisplayImpl extends TextBase {
     public function new() {
         super();
         tf = new FlxText();
-        tf.pixelPerfectPosition = true;
+        tf.pixelPerfectRender = true;
         tf.autoSize = true;
     }
     

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -185,6 +185,8 @@ class FlxTextInput extends TextBase {
             tf.displayAsPassword = _inputData.password;
         }
 
+        tf.type = (parentComponent.disabled ? DYNAMIC : INPUT);
+
         return measureTextRequired;
     }
 

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -142,8 +142,9 @@ class FlxTextInput extends TextBase {
         var measureTextRequired:Bool = false;
 
         if (_textStyle != null) {
-            if (tf.alignment != _textStyle.textAlign) {
-                tf.alignment = _textStyle.textAlign;
+            var textAlign = (_textStyle.textAlign != null ? _textStyle.textAlign : "left");
+            if (tf.alignment != textAlign) {
+                tf.alignment = textAlign;
             }
 
             var fontSizeValue = Std.int(_textStyle.fontSize);
@@ -162,13 +163,15 @@ class FlxTextInput extends TextBase {
                 tf.color = _textStyle.color;
             }
 
-            if (tf.bold != _textStyle.fontBold) {
-                tf.bold = _textStyle.fontBold;
+            var fontBold = (_textStyle.fontBold != null ? _textStyle.fontBold : false);
+            if (tf.bold != fontBold) {
+                tf.bold = fontBold;
                 measureTextRequired = true;
             }
             
-            if (tf.italic != _textStyle.fontItalic) {
-                tf.italic = _textStyle.fontItalic;
+            var fontItalic = (_textStyle.fontItalic != null ? _textStyle.fontItalic : false);
+            if (tf.italic != fontItalic) {
+                tf.italic = fontItalic;
                 measureTextRequired = true;
             }
         }

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -23,6 +23,8 @@ class FlxTextInput extends TextBase {
         tf.onChange.add(onInternalChange);
         tf.onScroll.add(onScroll);
         tf.moves = false;
+        _inputData.vscrollPageStep = 1;
+        _inputData.vscrollNativeWheel = true;
     }
 
     public override function focus() {

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -104,7 +104,7 @@ class FlxTextInput extends TextBase {
             tf.scrollH = hscrollValue;
         }
 
-        var vscrollValue = Std.int(_inputData.vscrollPos);
+        var vscrollValue = Std.int(_inputData.vscrollPos) + 1;
         if (tf.scrollV != vscrollValue) {
             tf.scrollV = vscrollValue;
         }
@@ -134,7 +134,7 @@ class FlxTextInput extends TextBase {
         // see below
         _inputData.hscrollPageSize = (_width * _inputData.hscrollMax) / _textWidth;
 
-        _inputData.vscrollMax = tf.maxScrollV;
+        _inputData.vscrollMax = tf.maxScrollV - 1;
         _inputData.vscrollPageSize = (_height * _inputData.vscrollMax) / _textHeight;
     }
 
@@ -370,7 +370,7 @@ class FlxTextInput extends TextBase {
     
     private function onScroll() {
         _inputData.hscrollPos = tf.scrollH;
-        _inputData.vscrollPos = tf.scrollV;
+        _inputData.vscrollPos = tf.scrollV - 1;
         
         if (_inputData.onScrollCallback != null) {
             _inputData.onScrollCallback();

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -22,6 +22,7 @@ class FlxTextInput extends TextBase {
         tf = new flixel.addons.text.FlxTextInput();
         tf.onChange.add(onInternalChange);
         tf.onScroll.add(onScroll);
+        tf.pixelPerfectRender = true;
         tf.moves = false;
         _inputData.vscrollPageStep = 1;
         _inputData.vscrollNativeWheel = true;

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -322,37 +322,41 @@ class FlxTextInput extends TextBase {
     public var onKeyDown(null, set):KeyboardEvent->Void;
     private function set_onKeyDown(value:KeyboardEvent->Void):KeyboardEvent->Void {
         if (_onKeyDown != null) {
-            tf.textField.removeEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
+            //tf.textField.removeEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
         }
         _onKeyDown = value;
         if (_onKeyDown != null) {
-            tf.textField.addEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
+            //tf.textField.addEventListener(KeyboardEvent.KEY_DOWN, __onTextInputKeyDown);
         }
         return value;
     }
 
+    /*
     private function __onTextInputKeyDown(e:KeyboardEvent) {
         if (_onKeyDown != null)
             _onKeyDown(e);
     }
+    */
 
     private var _onKeyUp:KeyboardEvent->Void = null;
     public var onKeyUp(null, set):KeyboardEvent->Void;
     private function set_onKeyUp(value:KeyboardEvent->Void):KeyboardEvent->Void {
         if (_onKeyUp != null) {
-            tf.textField.removeEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
+            //tf.textField.removeEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
         }
         _onKeyUp = value;
         if (_onKeyUp != null) {
-            tf.textField.addEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
+            //tf.textField.addEventListener(KeyboardEvent.KEY_UP, __onTextInputKeyUp);
         }
         return value;
     }
 
+    /*
     private function __onTextInputKeyUp(e:KeyboardEvent) {
         if (_onKeyUp != null)
             _onKeyUp(e);
     }
+    */
 
     private function onInternalChange() {
         _text = tf.text;

--- a/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
@@ -412,6 +412,8 @@ class OpenFLTextInput extends TextBase {
         if (tf.displayAsPassword != _inputData.password) {
             tf.displayAsPassword = _inputData.password;
         }
+
+        tf.type = (parentComponent.disabled ? DYNAMIC : INPUT);
         
         return measureTextRequired;
     }

--- a/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
@@ -348,7 +348,7 @@ class OpenFLTextInput extends TextBase {
         // see below
         _inputData.hscrollPageSize = (_width * _inputData.hscrollMax) / _textWidth;
 
-        _inputData.vscrollMax = tf.maxScrollV;
+        _inputData.vscrollMax = tf.maxScrollV - 1;
         // cant have page size yet as there seems to be an openfl issue with bottomScrollV
         // https://github.com/openfl/openfl/issues/2220
         _inputData.vscrollPageSize = (_height * _inputData.vscrollMax) / _textHeight;

--- a/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/OpenFLTextInput.hx
@@ -36,6 +36,8 @@ class OpenFLTextInput extends TextBase {
         tf.tabEnabled = false;
         //tf.stage.focus = null;
         tf.addEventListener(Event.CHANGE, onInternalChange);
+        _inputData.vscrollPageStep = 1;
+        _inputData.vscrollNativeWheel = true;
     }
     
     public override function focus() {


### PR DESCRIPTION
- Text input (Flixel & OpenFL) is now uneditable when its component is disabled
- Set text input `vscrollNativeWheel` to true (prevents HaxeUI from handling mouse wheel scrolling, as the text input handles it already) and `vscrollPageStep` to 1 (moves one line at a time, consistent with the OpenFL backend)
- Prevent Flixel text input variables being set to null where it isn't accepted (`alignment`, `bold` and `italic` variables), causing a refresh when it isn't needed
- Vscroll values in `_inputData` for the Flixel text input are now 0-based, which fixes the scroll bar not starting from the very top (consistent with the OpenFL text input)
- Removed the keyboard event listeners for the Flixel text input, as it's no longer needed since the latest release, which lets the events be dispatched to the stage
- OpenFL text input now sets `_inputData.vscrollMax` to a 0-based index, consistent with `_inputData.vscrollPos`
- Enable `pixelPerfectRender` for text display & input, consistent with the components

Before:

https://github.com/haxeui/haxeui-flixel/assets/85134252/11b71d4f-cec4-494a-8753-3786edf5c9fb

After:

https://github.com/haxeui/haxeui-flixel/assets/85134252/f099f024-fc21-4574-bc82-869b14ebce4b

