### PR TITLE
Rework mouse & keyboard events and implement missing event types

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -8,9 +8,6 @@ import flixel.text.FlxText.FlxTextBorderStyle;
 import haxe.ui.Toolkit;
 import haxe.ui.backend.TextInputImpl.TextInputEvent;
 import haxe.ui.backend.flixel.FlxStyleHelper;
-import haxe.ui.backend.flixel.KeyboardHelper;
-import haxe.ui.backend.flixel.MouseHelper;
-import haxe.ui.backend.flixel.StateHelper;
 import haxe.ui.core.Component;
 import haxe.ui.core.ImageDisplay;
 import haxe.ui.core.Platform;
@@ -24,8 +21,6 @@ import haxe.ui.filters.DropShadow;
 import haxe.ui.filters.Outline;
 import haxe.ui.geom.Rectangle;
 import haxe.ui.styles.Style;
-import haxe.ui.util.MathUtil;
-import openfl.events.Event;
 
 class ComponentImpl extends ComponentBase {
     private var _eventMap:Map<String, UIEvent->Void>;
@@ -487,18 +482,16 @@ class ComponentImpl extends ComponentBase {
 
             case KeyboardEvent.KEY_DOWN:
                 if (_eventMap.exists(KeyboardEvent.KEY_DOWN) == false) {
-                    KeyboardHelper.notify(KeyboardEvent.KEY_DOWN, __onKeyboardEvent);
-                    _eventMap.set(KeyboardEvent.KEY_DOWN, listener);
                     if (hasTextInput()) {
+                        _eventMap.set(KeyboardEvent.KEY_DOWN, listener);
                         getTextInput().onKeyDown = __onTextInputKeyboardEvent;
                     }
                 }
 
             case KeyboardEvent.KEY_UP:
                 if (_eventMap.exists(KeyboardEvent.KEY_UP) == false) {
-                    KeyboardHelper.notify(KeyboardEvent.KEY_UP, __onKeyboardEvent);
-                    _eventMap.set(KeyboardEvent.KEY_UP, listener);
                     if (hasTextInput()) {
+                        _eventMap.set(KeyboardEvent.KEY_UP, listener);
                         getTextInput().onKeyUp = __onTextInputKeyboardEvent;
                     }
                 }
@@ -534,21 +527,19 @@ class ComponentImpl extends ComponentBase {
                 }
 
             case KeyboardEvent.KEY_DOWN:
-                _eventMap.remove(type);
-                KeyboardHelper.remove(KeyboardEvent.KEY_DOWN, __onKeyboardEvent);
                 if (hasTextInput()) {
+                    _eventMap.remove(type);
                     getTextInput().onKeyDown = null;
                 }
 
             case KeyboardEvent.KEY_UP:
-                _eventMap.remove(type);
-                KeyboardHelper.remove(KeyboardEvent.KEY_UP, __onKeyboardEvent);
                 if (hasTextInput()) {
+                    _eventMap.remove(type);
                     getTextInput().onKeyUp = null;
                 }
                 
             case UIEvent.CHANGE:
-                if (hasTextInput() == true) {
+                if (hasTextInput()) {
                     _eventMap.remove(type);
                     getTextInput().onChange = null;
                 }
@@ -600,19 +591,6 @@ class ComponentImpl extends ComponentBase {
     private function applyRootLayout(l:String) {
     }
     #end
-
-    private function __onKeyboardEvent(event:KeyboardEvent) {
-        if (this.state != StateHelper.currentState) {
-            return;
-        }
-
-        var fn = _eventMap.get(event.type);
-        if (fn == null) {
-            return;
-        }
-
-        fn(event);
-    }
 
     private function __onTextInputKeyboardEvent(event:openfl.events.KeyboardEvent) {
         var type = switch (event.type) {

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -796,9 +796,7 @@ class ComponentImpl extends ComponentBase {
                     var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
                     mouseEvent.screenX = x / Toolkit.scaleX;
                     mouseEvent.screenY = y / Toolkit.scaleY;
-                    #if mobile
-                    mouseEvent.touchEvent = true;
-                    #end
+                    mouseEvent.touchEvent = event.touchEvent;
                     fn(mouseEvent);
                     event.canceled = mouseEvent.canceled;
                 }
@@ -809,12 +807,17 @@ class ComponentImpl extends ComponentBase {
         var i = inBounds(x, y);
         if (i == true) {
             if (hasComponentOver(cast this, x, y) == true) {
-                var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_OUT);
-                if (fn != null) {
-                    var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
-                    mouseEvent.screenX = x / Toolkit.scaleX;
-                    mouseEvent.screenY = y / Toolkit.scaleY;
-                    fn(mouseEvent);
+                if (_mouseOverFlag == true) {
+                    _mouseOverFlag = false;
+                    var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_OUT);
+                    if (fn != null) {
+                        var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
+                        mouseEvent.screenX = x / Toolkit.scaleX;
+                        mouseEvent.screenY = y / Toolkit.scaleY;
+                        mouseEvent.touchEvent = event.touchEvent;
+                        fn(mouseEvent);
+                        event.canceled = mouseEvent.canceled;
+                    }
                 }
                 return;
             }
@@ -823,10 +826,11 @@ class ComponentImpl extends ComponentBase {
             }
             var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_MOVE);
             if (fn != null) {
-                var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_MOVE);
-                mouseEvent.screenX = x / Toolkit.scaleX;
-                mouseEvent.screenY = y / Toolkit.scaleY;
-                fn(mouseEvent);
+                event.screenX = x / Toolkit.scaleX;
+                event.screenY = y / Toolkit.scaleY;
+                fn(event);
+                event.screenX = x;
+                event.screenY = y;
             }
         }
         if (i == true && _mouseOverFlag == false) {
@@ -839,7 +843,9 @@ class ComponentImpl extends ComponentBase {
                 var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OVER);
                 mouseEvent.screenX = x / Toolkit.scaleX;
                 mouseEvent.screenY = y / Toolkit.scaleY;
+                mouseEvent.touchEvent = event.touchEvent;
                 fn(mouseEvent);
+                event.canceled = mouseEvent.canceled;
             }
         } else if (i == false && _mouseOverFlag == true) {
             _mouseOverFlag = false;
@@ -849,7 +855,9 @@ class ComponentImpl extends ComponentBase {
                 var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
                 mouseEvent.screenX = x / Toolkit.scaleX;
                 mouseEvent.screenY = y / Toolkit.scaleY;
+                mouseEvent.touchEvent = event.touchEvent;
                 fn(mouseEvent);
+                event.canceled = mouseEvent.canceled;
             }
         }
     }
@@ -861,7 +869,6 @@ class ComponentImpl extends ComponentBase {
             return;
         }
 
-        var button:Int = event.data;
         var x = event.screenX;
         var y = event.screenY;
 
@@ -874,13 +881,13 @@ class ComponentImpl extends ComponentBase {
             }
             _mouseDownFlag = true;
 
-            var type = button == 0 ? haxe.ui.events.MouseEvent.MOUSE_DOWN: haxe.ui.events.MouseEvent.RIGHT_MOUSE_DOWN;
-            var fn:UIEvent->Void = _eventMap.get(type);
+            var fn:UIEvent->Void = _eventMap.get(event.type);
             if (fn != null) {
-                var mouseEvent = new haxe.ui.events.MouseEvent(type);
-                mouseEvent.screenX = x / Toolkit.scaleX;
-                mouseEvent.screenY = y / Toolkit.scaleY;
-                fn(mouseEvent);
+                event.screenX = x / Toolkit.scaleX;
+                event.screenY = y / Toolkit.scaleY;
+                fn(event);
+                event.screenX = x;
+                event.screenY = y;
             }
         }
     }
@@ -911,7 +918,9 @@ class ComponentImpl extends ComponentBase {
                     var mouseEvent = new haxe.ui.events.MouseEvent(type);
                     mouseEvent.screenX = x / Toolkit.scaleX;
                     mouseEvent.screenY = y / Toolkit.scaleY;
+                    mouseEvent.touchEvent = event.touchEvent;
                     fn(mouseEvent);
+                    event.canceled = mouseEvent.canceled;
                 }
 
                 if (type == haxe.ui.events.MouseEvent.CLICK) {
@@ -925,13 +934,13 @@ class ComponentImpl extends ComponentBase {
             }
 
             _mouseDownFlag = false;
-            var type = button == 0 ? haxe.ui.events.MouseEvent.MOUSE_UP: haxe.ui.events.MouseEvent.RIGHT_MOUSE_UP;
-            var fn:UIEvent->Void = _eventMap.get(type);
+            var fn:UIEvent->Void = _eventMap.get(event.type);
             if (fn != null) {
-                var mouseEvent = new haxe.ui.events.MouseEvent(type);
-                mouseEvent.screenX = x / Toolkit.scaleX;
-                mouseEvent.screenY = y / Toolkit.scaleY;
-                fn(mouseEvent);
+                event.screenX = x / Toolkit.scaleX;
+                event.screenY = y / Toolkit.scaleY;
+                fn(event);
+                event.screenX = x;
+                event.screenY = y;
             }
         }
         _mouseDownFlag = false;        
@@ -958,13 +967,13 @@ class ComponentImpl extends ComponentBase {
             _mouseDownFlag = false;
             var mouseDelta:Float = MathUtil.distance(x, y, _lastClickX, _lastClickY);
             if (_lastClickTimeDiff < 0.5 && mouseDelta < 5) { // 0.5 seconds
-                var type = haxe.ui.events.MouseEvent.DBL_CLICK;
-                var fn:UIEvent->Void = _eventMap.get(type);
+                var fn:UIEvent->Void = _eventMap.get(event.type);
                 if (fn != null) {
-                    var mouseEvent = new haxe.ui.events.MouseEvent(type);
-                    mouseEvent.screenX = x / Toolkit.scaleX;
-                    mouseEvent.screenY = y / Toolkit.scaleY;
-                    fn(mouseEvent);
+                    event.screenX = x / Toolkit.scaleX;
+                    event.screenY = y / Toolkit.scaleY;
+                    fn(event);
+                    event.screenX = x;
+                    event.screenY = y;
                 }
             }
         }
@@ -977,25 +986,23 @@ class ComponentImpl extends ComponentBase {
         }
         
         var delta = event.delta;
+        var x = event.screenX;
+        var y = event.screenY;
         var fn = _eventMap.get(MouseEvent.MOUSE_WHEEL);
 
         if (fn == null) {
             return;
         }
 
-        if (!inBounds(lastMouseX, lastMouseY)) {
+        if (!inBounds(x, y)) {
             return;
         }
 
-        var mouseEvent = new MouseEvent(MouseEvent.MOUSE_WHEEL);
-        mouseEvent.screenX = lastMouseX / Toolkit.scaleX;
-        mouseEvent.screenY = lastMouseY / Toolkit.scaleY;
-        mouseEvent.delta = Math.max(-1, Math.min(1, -delta));
-        if (Platform.instance.isMobile) {
-            mouseEvent.touchEvent = true;
-        }
-        fn(mouseEvent);
-        event.canceled = mouseEvent.canceled;
+        event.screenX = x / Toolkit.scaleX;
+        event.screenY = y / Toolkit.scaleY;
+        fn(event);
+        event.screenX = x;
+        event.screenY = y;
     }
 
     private function __onKeyboardEvent(event:KeyboardEvent) {
@@ -1008,13 +1015,7 @@ class ComponentImpl extends ComponentBase {
             return;
         }
 
-        var keyboardEvent = new KeyboardEvent(event.type);
-        keyboardEvent.keyCode = event.keyCode;
-        keyboardEvent.altKey = event.altKey;
-        keyboardEvent.ctrlKey = event.ctrlKey;
-        keyboardEvent.shiftKey = event.shiftKey;
-        fn(keyboardEvent);
-        event.canceled = keyboardEvent.canceled;
+        fn(event);
     }
 
     private function __onTextInputKeyboardEvent(event:openfl.events.KeyboardEvent) {

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -32,15 +32,6 @@ class ComponentImpl extends ComponentBase {
     
     private var _surface:FlxSprite;
     
-    private var lastMouseX:Float = -1;
-    private var lastMouseY:Float = -1;
-    
-    // For doubleclick detection
-    private var _lastClickTime:Float = 0;
-    private var _lastClickTimeDiff:Float = MathUtil.MAX_INT;
-    private var _lastClickX:Float = -1;
-    private var _lastClickY:Float = -1;
-    
     private var asComponent:Component;
 
     public function new() {
@@ -470,94 +461,28 @@ class ComponentImpl extends ComponentBase {
     //***********************************************************************************************************
     private override function mapEvent(type:String, listener:UIEvent->Void) {
         switch (type) {
-            case MouseEvent.MOUSE_MOVE:
-                if (_eventMap.exists(MouseEvent.MOUSE_MOVE) == false) {
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.MOUSE_MOVE, listener);
-                }
-                
-            case MouseEvent.MOUSE_OVER:
-                if (_eventMap.exists(MouseEvent.MOUSE_OVER) == false) {
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.MOUSE_OVER, listener);
-                }
-                
-            case MouseEvent.MOUSE_OUT:
-                if (_eventMap.exists(MouseEvent.MOUSE_OUT) == false) {
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.MOUSE_OUT, listener);
-                }
-
             case MouseEvent.MOUSE_DOWN:
                 if (_eventMap.exists(MouseEvent.MOUSE_DOWN) == false) {
-                    notifyMouseDown(true);
-                    notifyMouseUp(true);
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.MOUSE_DOWN, listener);
                     if (hasTextInput()) {
+                        _eventMap.set(MouseEvent.MOUSE_DOWN, listener);
                         getTextInput().onMouseDown = __onTextInputMouseEvent;
                     }
                 }
 
             case MouseEvent.MOUSE_UP:
                 if (_eventMap.exists(MouseEvent.MOUSE_UP) == false) {
-                    notifyMouseDown(true);
-                    notifyMouseUp(true);
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.MOUSE_UP, listener);
                     if (hasTextInput()) {
+                        _eventMap.set(MouseEvent.MOUSE_UP, listener);
                         getTextInput().onMouseUp = __onTextInputMouseEvent;
                     }
                 }
                 
-            case MouseEvent.MOUSE_WHEEL:
-                if (_eventMap.exists(MouseEvent.MOUSE_WHEEL) == false) {
-                    notifyMouseMove(true);
-                    notifyMouseWheel(true);
-                    _eventMap.set(MouseEvent.MOUSE_WHEEL, listener);
-                }
-                
             case MouseEvent.CLICK:
                 if (_eventMap.exists(MouseEvent.CLICK) == false) {
-                    notifyMouseDown(true);
-                    notifyMouseUp(true);
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.CLICK, listener);
                     if (hasTextInput()) {
+                        _eventMap.set(MouseEvent.CLICK, listener);
                         getTextInput().onClick = __onTextInputMouseEvent;
                     }
-                }
-                
-            case MouseEvent.DBL_CLICK:
-                if (_eventMap.exists(MouseEvent.DBL_CLICK) == false) {
-                    notifyMouseDown(true);
-                    notifyMouseUp(true);
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.DBL_CLICK, listener);
-                }
-                
-            case MouseEvent.RIGHT_MOUSE_DOWN:
-                if (_eventMap.exists(MouseEvent.RIGHT_MOUSE_DOWN) == false) {
-                    notifyMouseDown(true);
-                    notifyMouseUp(true);
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.RIGHT_MOUSE_DOWN, listener);
-                }
-
-            case MouseEvent.RIGHT_MOUSE_UP:
-                if (_eventMap.exists(MouseEvent.RIGHT_MOUSE_UP) == false) {
-                    notifyMouseDown(true);
-                    notifyMouseUp(true);
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.RIGHT_MOUSE_UP, listener);
-                }
-                
-            case MouseEvent.RIGHT_CLICK:
-                if (_eventMap.exists(MouseEvent.RIGHT_CLICK) == false) {
-                    notifyMouseDown(true);
-                    notifyMouseUp(true);
-                    notifyMouseMove(true);
-                    _eventMap.set(MouseEvent.RIGHT_CLICK, listener);
                 }
 
             case KeyboardEvent.KEY_DOWN:
@@ -590,73 +515,23 @@ class ComponentImpl extends ComponentBase {
 
     private override function unmapEvent(type:String, listener:UIEvent->Void) {
         switch (type) {
-            case MouseEvent.MOUSE_MOVE:
-                _eventMap.remove(type);
-                notifyMouseMove(false);
-                
-            case MouseEvent.MOUSE_OVER:
-                _eventMap.remove(type);
-                notifyMouseMove(false);
-                
-            case MouseEvent.MOUSE_OUT:
-                _eventMap.remove(type);
-                notifyMouseMove(false);
-
             case MouseEvent.MOUSE_DOWN:
-                _eventMap.remove(type);
-                notifyMouseDown(false);
-                notifyMouseUp(false);
-                notifyMouseMove(false);
                 if (hasTextInput()) {
+                    _eventMap.remove(type);
                     getTextInput().onMouseDown = null;
                 }
 
             case MouseEvent.MOUSE_UP:
-                _eventMap.remove(type);
-                notifyMouseDown(false);
-                notifyMouseUp(false);
-                notifyMouseMove(false);
                 if (hasTextInput()) {
+                    _eventMap.remove(type);
                     getTextInput().onMouseUp = null;
                 }
                 
-            case MouseEvent.MOUSE_WHEEL:
-                _eventMap.remove(type);
-                notifyMouseMove(false);
-                notifyMouseWheel(false);
-                
             case MouseEvent.CLICK:
-                _eventMap.remove(type);
-                notifyMouseDown(false);
-                notifyMouseUp(false);
-                notifyMouseMove(false);
                 if (hasTextInput()) {
+                    _eventMap.remove(type);
                     getTextInput().onClick = null;
                 }
-                
-            case MouseEvent.DBL_CLICK:
-                _eventMap.remove(type);
-                notifyMouseDown(false);
-                notifyMouseUp(false);
-                notifyMouseMove(false);
-                
-            case MouseEvent.RIGHT_MOUSE_DOWN:
-                _eventMap.remove(type);
-                notifyMouseDown(false);
-                notifyMouseUp(false);
-                notifyMouseMove(false);
-
-            case MouseEvent.RIGHT_MOUSE_UP:
-                _eventMap.remove(type);
-                notifyMouseDown(false);
-                notifyMouseUp(false);
-                notifyMouseMove(false);
-                
-            case MouseEvent.RIGHT_CLICK:
-                _eventMap.remove(type);
-                notifyMouseDown(false);
-                notifyMouseUp(false);
-                notifyMouseMove(false);
 
             case KeyboardEvent.KEY_DOWN:
                 _eventMap.remove(type);
@@ -673,75 +548,10 @@ class ComponentImpl extends ComponentBase {
                 }
                 
             case UIEvent.CHANGE:
-                _eventMap.remove(type);
                 if (hasTextInput() == true) {
+                    _eventMap.remove(type);
                     getTextInput().onChange = null;
                 }
-        }
-    }
-
-    private var _counterNotifyMouseDown:Int = 0;
-    private function notifyMouseDown(notify:Bool) {
-        if (notify == true) {
-            _counterNotifyMouseDown++;
-        } else {
-            _counterNotifyMouseDown--;
-            if (_counterNotifyMouseDown < 0) {
-                _counterNotifyMouseDown = 0;
-            }
-        }
-        if (notify == true && _counterNotifyMouseDown == 1) {
-            MouseHelper.notify(MouseEvent.MOUSE_DOWN, __onMouseDown);
-        } else if (notify == false && _counterNotifyMouseDown == 0) {
-            MouseHelper.remove(MouseEvent.MOUSE_DOWN, __onMouseDown);
-        }
-    }
-    
-    private var _counterNotifyMouseUp:Int = 0;
-    private function notifyMouseUp(notify:Bool) {
-        if (notify == true) {
-            _counterNotifyMouseUp++;
-        } else {
-            _counterNotifyMouseUp--;
-            if (_counterNotifyMouseUp < 0) {
-                _counterNotifyMouseUp = 0;
-            }
-        }
-        if (notify == true && _counterNotifyMouseUp == 1) {
-            MouseHelper.notify(MouseEvent.MOUSE_UP, __onMouseUp);
-        } else if (notify == false && _counterNotifyMouseUp == 0) {
-            MouseHelper.remove(MouseEvent.MOUSE_UP, __onMouseUp);
-        }
-    }
-    
-    private var _counterNotifyMouseMove:Int = 0;
-    private function notifyMouseMove(notify:Bool) {
-        if (notify == true) {
-            _counterNotifyMouseMove++;
-        } else {
-            _counterNotifyMouseMove--;
-            if (_counterNotifyMouseMove < 0) {
-                _counterNotifyMouseMove = 0;
-            }
-        }
-        if (notify == true && _counterNotifyMouseMove == 1) {
-            MouseHelper.notify(MouseEvent.MOUSE_MOVE, __onMouseMove);
-        } else if (notify == false && _counterNotifyMouseMove == 0) {
-            MouseHelper.remove(MouseEvent.MOUSE_MOVE, __onMouseMove);
-        }
-    }
-    
-    private var _counterNotifyMouseWheel:Int = 0;
-    private function notifyMouseWheel(notify:Bool) {
-        if (notify == true) {
-            _counterNotifyMouseWheel++;
-        } else {
-            _counterNotifyMouseWheel--;
-        }
-        if (notify == true && _counterNotifyMouseWheel == 1) {
-            MouseHelper.notify(MouseEvent.MOUSE_WHEEL, __onMouseWheel);
-        } else if (notify == false && _counterNotifyMouseWheel == 0) {
-            MouseHelper.remove(MouseEvent.MOUSE_WHEEL, __onMouseWheel);
         }
     }
     
@@ -774,236 +584,22 @@ class ComponentImpl extends ComponentBase {
         }
     }
     
+    /*
     private var _mouseOverFlag:Bool = false;
     private var _cursorSet:Bool = false;
-    private function __onMouseMove(event:MouseEvent) {
-        if (Platform.instance.isMobile) {
-            return;
-        }
-
-        var x = event.screenX;
-        var y = event.screenY;
-        lastMouseX = x;
-        lastMouseY = y;
-        
-        var inCurrentState = (this.state == StateHelper.currentState);
-
-        if (inCurrentState == false) {
-            if (_mouseOverFlag == true) {
-                _mouseOverFlag = false;
-                var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_OUT);
-                if (fn != null) {
-                    var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
-                    mouseEvent.screenX = x / Toolkit.scaleX;
-                    mouseEvent.screenY = y / Toolkit.scaleY;
-                    mouseEvent.touchEvent = event.touchEvent;
-                    fn(mouseEvent);
-                    event.canceled = mouseEvent.canceled;
-                }
-            }
-            return;
-        }
-
-        var i = inBounds(x, y);
-        if (i == true) {
-            if (hasComponentOver(cast this, x, y) == true) {
-                if (_mouseOverFlag == true) {
-                    _mouseOverFlag = false;
-                    var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_OUT);
-                    if (fn != null) {
-                        var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
-                        mouseEvent.screenX = x / Toolkit.scaleX;
-                        mouseEvent.screenY = y / Toolkit.scaleY;
-                        mouseEvent.touchEvent = event.touchEvent;
-                        fn(mouseEvent);
-                        event.canceled = mouseEvent.canceled;
-                    }
-                }
-                return;
-            }
-            if (this.style != null && this.style.cursor != null) {
-                Screen.instance.setCursor(this.style.cursor, this.style.cursorOffsetX, this.style.cursorOffsetY);
-            }
-            var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_MOVE);
-            if (fn != null) {
-                event.screenX = x / Toolkit.scaleX;
-                event.screenY = y / Toolkit.scaleY;
-                fn(event);
-                event.screenX = x;
-                event.screenY = y;
-            }
-        }
-        if (i == true && _mouseOverFlag == false) {
-            if (hasComponentOver(cast this, x, y) == true) {
-                return;
-            }
-            _mouseOverFlag = true;
-            var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_OVER);
-            if (fn != null) {
-                var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OVER);
-                mouseEvent.screenX = x / Toolkit.scaleX;
-                mouseEvent.screenY = y / Toolkit.scaleY;
-                mouseEvent.touchEvent = event.touchEvent;
-                fn(mouseEvent);
-                event.canceled = mouseEvent.canceled;
-            }
-        } else if (i == false && _mouseOverFlag == true) {
-            _mouseOverFlag = false;
-            Screen.instance.setCursor("default");
-            var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_OUT);
-            if (fn != null) {
-                var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
-                mouseEvent.screenX = x / Toolkit.scaleX;
-                mouseEvent.screenY = y / Toolkit.scaleY;
-                mouseEvent.touchEvent = event.touchEvent;
-                fn(mouseEvent);
-                event.canceled = mouseEvent.canceled;
-            }
-        }
+    private function __onMouseOver(event:MouseEvent) {
+        _mouseOverFlag = true;
     }
 
-    private var _mouseDownFlag:Bool = false;
-    private var _mouseDownButton:Int = -1;
-    private function __onMouseDown(event:MouseEvent) {
-        if (this.state != StateHelper.currentState) {
-            return;
-        }
-
-        var x = event.screenX;
-        var y = event.screenY;
-
-        lastMouseX = x;
-        lastMouseY = y;
-        var i = inBounds(x, y);
-        if (i == true && _mouseDownFlag == false) {
-            if (hasComponentOver(cast this, x, y) == true) {
-                return;
-            }
-            _mouseDownFlag = true;
-
-            var fn:UIEvent->Void = _eventMap.get(event.type);
-            if (fn != null) {
-                event.screenX = x / Toolkit.scaleX;
-                event.screenY = y / Toolkit.scaleY;
-                fn(event);
-                event.screenX = x;
-                event.screenY = y;
-            }
-        }
+    private function __onMouseOut(event:MouseEvent) {
+        _mouseOverFlag = false;
     }
-
-    private function __onMouseUp(event:MouseEvent) {
-        if (this.state != StateHelper.currentState) {
-            return;
-        }
-
-        var button:Int = event.data;
-        var x = event.screenX;
-        var y = event.screenY;
-
-        lastMouseX = x;
-        lastMouseY = y;
-
-        var i = inBounds(x, y);
-        if (i == true) {
-            /*
-            if (hasComponentOver(cast this, x, y) == true) {
-                return;
-            }
-            */
-            if (_mouseDownFlag == true) {
-                var type = button == 0 ? haxe.ui.events.MouseEvent.CLICK: haxe.ui.events.MouseEvent.RIGHT_CLICK;
-                var fn:UIEvent->Void = _eventMap.get(type);
-                if (fn != null) {
-                    var mouseEvent = new haxe.ui.events.MouseEvent(type);
-                    mouseEvent.screenX = x / Toolkit.scaleX;
-                    mouseEvent.screenY = y / Toolkit.scaleY;
-                    mouseEvent.touchEvent = event.touchEvent;
-                    fn(mouseEvent);
-                    event.canceled = mouseEvent.canceled;
-                }
-
-                if (type == haxe.ui.events.MouseEvent.CLICK) {
-                    _lastClickTimeDiff = Timer.stamp() - _lastClickTime;
-                    _lastClickTime = Timer.stamp();
-                    if (_lastClickTimeDiff >= 0.5) { // 0.5 seconds
-                        _lastClickX = x;
-                        _lastClickY = y;
-                    }
-                }
-            }
-
-            _mouseDownFlag = false;
-            var fn:UIEvent->Void = _eventMap.get(event.type);
-            if (fn != null) {
-                event.screenX = x / Toolkit.scaleX;
-                event.screenY = y / Toolkit.scaleY;
-                fn(event);
-                event.screenX = x;
-                event.screenY = y;
-            }
-        }
-        _mouseDownFlag = false;        
-    }
+    */
 
     #if haxeui_dont_impose_base_class
     private function applyRootLayout(l:String) {
     }
     #end
-    
-    private function __onDoubleClick(event:MouseEvent) {
-        var button:Int = event.data;
-        var x = event.screenX;
-        var y = event.screenY;
-
-        lastMouseX = x;
-        lastMouseY = y;
-        var i = inBounds(x, y);
-        if (i == true && button == 0) {
-            if (hasComponentOver(cast this, x, y) == true) {
-                return;
-            }
-
-            _mouseDownFlag = false;
-            var mouseDelta:Float = MathUtil.distance(x, y, _lastClickX, _lastClickY);
-            if (_lastClickTimeDiff < 0.5 && mouseDelta < 5) { // 0.5 seconds
-                var fn:UIEvent->Void = _eventMap.get(event.type);
-                if (fn != null) {
-                    event.screenX = x / Toolkit.scaleX;
-                    event.screenY = y / Toolkit.scaleY;
-                    fn(event);
-                    event.screenX = x;
-                    event.screenY = y;
-                }
-            }
-        }
-        _mouseDownFlag = false;
-    }
-
-    private function __onMouseWheel(event:MouseEvent) {
-        if (this.state != StateHelper.currentState) {
-            return;
-        }
-        
-        var delta = event.delta;
-        var x = event.screenX;
-        var y = event.screenY;
-        var fn = _eventMap.get(MouseEvent.MOUSE_WHEEL);
-
-        if (fn == null) {
-            return;
-        }
-
-        if (!inBounds(x, y)) {
-            return;
-        }
-
-        event.screenX = x / Toolkit.scaleX;
-        event.screenY = y / Toolkit.scaleY;
-        fn(event);
-        event.screenX = x;
-        event.screenY = y;
-    }
 
     private function __onKeyboardEvent(event:KeyboardEvent) {
         if (this.state != StateHelper.currentState) {

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -26,6 +26,7 @@ class ScreenImpl extends ScreenBase {
         _mapping = new Map<String, UIEvent->Void>();
 
         MouseHelper.init();
+        KeyboardHelper.init();
 
         FlxG.signals.postGameStart.add(onPostGameStart);
         FlxG.signals.postStateSwitch.add(onPostStateSwitch);
@@ -282,8 +283,7 @@ class ScreenImpl extends ScreenBase {
             || type == MouseEvent.MIDDLE_MOUSE_UP
             || type == UIEvent.RESIZE
             || type == KeyboardEvent.KEY_DOWN
-            || type == KeyboardEvent.KEY_UP
-            || type == KeyboardEvent.KEY_PRESS) {
+            || type == KeyboardEvent.KEY_UP) {
                 return true;
             }
         return false;

--- a/haxe/ui/backend/flixel/KeyboardHelper.hx
+++ b/haxe/ui/backend/flixel/KeyboardHelper.hx
@@ -1,7 +1,9 @@
 package haxe.ui.backend.flixel;
 
 import flixel.FlxG;
+import haxe.ui.core.Component;
 import haxe.ui.events.KeyboardEvent;
+import haxe.ui.focus.FocusManager;
 
 typedef KeyboardCallback = {
     var fn:KeyboardEvent->Void;
@@ -9,25 +11,21 @@ typedef KeyboardCallback = {
 }
 
 class KeyboardHelper {
-    private static var _hasOnKeyDown:Bool = false;
-    private static var _hasOnKeyUp:Bool = false;
-
+    private static var _initialized = false;
     private static var _callbacks:Map<String, Array<KeyboardCallback>> = new Map<String, Array<KeyboardCallback>>();
+
+    public static function init() {
+        if (_initialized == true) {
+            return;
+        }
+        
+        _initialized = true;
+
+        FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_DOWN, onKeyDown);
+        FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_UP, onKeyUp);
+    }
     
     public static function notify(event:String, callback:KeyboardEvent->Void, priority:Int = 5) {
-        switch (event) {
-            case KeyboardEvent.KEY_DOWN:
-                if (_hasOnKeyDown == false) {
-                    FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_DOWN, onKeyDown);
-                    _hasOnKeyDown = true;
-                }
-            case KeyboardEvent.KEY_UP:
-                if (_hasOnKeyUp == false) {
-                    FlxG.stage.addEventListener(openfl.events.KeyboardEvent.KEY_UP, onKeyUp);
-                    _hasOnKeyUp = true;
-                }
-        }
-
         var list = _callbacks.get(event);
         if (list == null) {
             list = new Array<KeyboardCallback>();
@@ -52,19 +50,6 @@ class KeyboardHelper {
             removeCallback(list, callback);
             if (list.length == 0) {
                 _callbacks.remove(event);
-                
-                switch (event) {
-                    case KeyboardEvent.KEY_DOWN:
-                        if (_hasOnKeyDown == true) {
-                            FlxG.stage.removeEventListener(openfl.events.KeyboardEvent.KEY_DOWN, onKeyDown);
-                            _hasOnKeyDown = false;
-                        }
-                    case KeyboardEvent.KEY_UP:
-                        if (_hasOnKeyUp == true) {
-                            FlxG.stage.removeEventListener(openfl.events.KeyboardEvent.KEY_UP, onKeyUp);
-                            _hasOnKeyUp = false;
-                        }
-                }
             }
         }
     }
@@ -78,6 +63,25 @@ class KeyboardHelper {
     }
 
     private static function dispatchEvent(type:String, e:openfl.events.KeyboardEvent) {
+        var event = new KeyboardEvent(type);
+        event.keyCode = e.keyCode;
+        event.altKey = e.altKey;
+        event.ctrlKey = e.ctrlKey;
+        event.shiftKey = e.shiftKey;
+        
+        var target = getTarget();
+        // recreate a bubbling effect, so components will pass events onto their parents
+        // can't use the `bubble` property as it causes a crash when `target` isn't the expected result, for example, on ListView.onRendererClick
+        while (target != null) {
+            if (target.hasEvent(event.type)) {
+                target.dispatch(event);
+                if (event.canceled == true) {
+                    return;
+                }
+            }
+            target = target.parentComponent;
+        }
+
         var list = _callbacks.get(type);
         if (list == null || list.length == 0) {
             return;
@@ -85,18 +89,20 @@ class KeyboardHelper {
         
         list = list.copy();
 
-        var event = new KeyboardEvent(type);
-        event.keyCode = e.keyCode;
-        event.altKey = e.altKey;
-        event.ctrlKey = e.ctrlKey;
-        event.shiftKey = e.shiftKey;
-
         for (l in list) {
             l.fn(event);
             if (event.canceled == true) {
                 break;
             }
         }
+    }
+
+    private static function getTarget():Component {
+        var target:Component = cast FocusManager.instance.focus;
+        if (target != null && target.state == StateHelper.currentState) {
+            return target;
+        }
+        return null;
     }
 
     private static function hasCallback(list:Array<KeyboardCallback>, fn:KeyboardEvent->Void):Bool {

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -1,6 +1,7 @@
 package haxe.ui.backend.flixel;
 
 import flixel.FlxG;
+import haxe.ui.core.Platform;
 import haxe.ui.events.MouseEvent;
 
 typedef MouseCallback = {
@@ -136,6 +137,9 @@ class MouseHelper {
             event.screenX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
             event.screenY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
         }
+        if (Platform.instance.isMobile) {
+            event.touchEvent = true;
+        }
 
         event.data = -1;
         if (e.type == openfl.events.MouseEvent.MOUSE_DOWN) {
@@ -173,6 +177,9 @@ class MouseHelper {
             event.screenX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
             event.screenY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
         }
+        if (Platform.instance.isMobile) {
+            event.touchEvent = true;
+        }
 
         event.data = -1;
         if (e.type == openfl.events.MouseEvent.MOUSE_UP) {
@@ -209,6 +216,9 @@ class MouseHelper {
             event.screenX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
             event.screenY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
         }
+        if (Platform.instance.isMobile) {
+            event.touchEvent = true;
+        }
 
         for (l in list) {
             l.fn(event);
@@ -227,7 +237,12 @@ class MouseHelper {
         list = list.copy();
         
         var event = new MouseEvent(MouseEvent.MOUSE_WHEEL);
-        event.delta = -e.delta;
+        event.screenX = (e.stageX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
+        event.screenY = (e.stageY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
+        event.delta = Math.max(-1, Math.min(1, e.delta));
+        if (Platform.instance.isMobile) {
+            event.touchEvent = true;
+        }
         for (l in list) {
             l.fn(event);
             if (event.canceled == true) {

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -1,7 +1,9 @@
 package haxe.ui.backend.flixel;
 
 import flixel.FlxG;
+import haxe.ui.core.Component;
 import haxe.ui.core.Platform;
+import haxe.ui.core.Screen;
 import haxe.ui.events.MouseEvent;
 
 typedef MouseCallback = {
@@ -12,41 +14,42 @@ typedef MouseCallback = {
 class MouseHelper {
     public static var currentMouseX:Float = 0;
     public static var currentMouseY:Float = 0;
+    public static var currentWorldX:Float = 0;
+    public static var currentWorldY:Float = 0;
     
-    private static var _hasOnMouseDown:Bool = false;
-    private static var _hasOnMouseUp:Bool = false;
-    private static var _hasOnMouseMove:Bool = false;
-    private static var _hasOnMouseWheel:Bool = false;
-    
+    private static var _initialized = false;
     private static var _callbacks:Map<String, Array<MouseCallback>> = new Map<String, Array<MouseCallback>>();
-    
-    public static function notify(event:String, callback:MouseEvent->Void, priority:Int = 5) {
-        switch (event) {
-            case MouseEvent.MOUSE_DOWN:
-                if (_hasOnMouseDown == false) {
-                    FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_DOWN, onMouseDown);
-                    FlxG.stage.addEventListener(openfl.events.MouseEvent.RIGHT_MOUSE_DOWN, onMouseDown);
-                    _hasOnMouseDown = true;
-                }
-            case MouseEvent.MOUSE_UP:
-                if (_hasOnMouseUp == false) {
-                    FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_UP, onMouseUp);
-                    FlxG.stage.addEventListener(openfl.events.MouseEvent.RIGHT_MOUSE_UP, onMouseUp);
-                    _hasOnMouseUp = true;
-                    FlxG.signals.preStateSwitch.add(onPreStateSwitched);
-                }
-            case MouseEvent.MOUSE_MOVE:
-                if (_hasOnMouseMove == false) {
-                    FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_MOVE, onMouseMove);
-                    _hasOnMouseMove = true;
-                }
-            case MouseEvent.MOUSE_WHEEL:
-                if (_hasOnMouseWheel == false) {
-                    FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_WHEEL, onMouseWheel);
-                    _hasOnMouseWheel = true;
-                }
+
+    private static var _mouseDownLeft:Dynamic;
+    private static var _mouseDownMiddle:Dynamic;
+    private static var _mouseDownRight:Dynamic;
+    private static var _lastClickTarget:Dynamic;
+    private static var _lastClickTime:Float;
+    private static var _mouseOverTarget:Dynamic;
+
+    public static function init() {
+        if (_initialized == true) {
+            return;
         }
         
+        _initialized = true;
+
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_DOWN, onMouseDown);
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.RIGHT_MOUSE_DOWN, onMouseDown);
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.MIDDLE_MOUSE_DOWN, onMouseDown);
+
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_UP, onMouseUp);
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.RIGHT_MOUSE_UP, onMouseUp);
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.MIDDLE_MOUSE_UP, onMouseUp);
+
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_MOVE, onMouseMove);
+
+        FlxG.stage.addEventListener(openfl.events.MouseEvent.MOUSE_WHEEL, onMouseWheel);
+
+        FlxG.signals.preStateSwitch.add(onPreStateSwitched);
+    }
+    
+    public static function notify(event:String, callback:MouseEvent->Void, priority:Int = 5) {
         var list = _callbacks.get(event);
         if (list == null) {
             list = new Array<MouseCallback>();
@@ -71,154 +74,152 @@ class MouseHelper {
             removeCallback(list, callback);
             if (list.length == 0) {
                 _callbacks.remove(event);
-                
-                switch (event) {
-                    case MouseEvent.MOUSE_DOWN:
-                        if (_hasOnMouseDown == true) {
-                            FlxG.stage.removeEventListener(openfl.events.MouseEvent.MOUSE_DOWN, onMouseDown);
-                            FlxG.stage.removeEventListener(openfl.events.MouseEvent.RIGHT_MOUSE_DOWN, onMouseDown);
-                            _hasOnMouseDown = false;
-                        }
-                    case MouseEvent.MOUSE_UP:
-                        if (_hasOnMouseUp == true) {
-                            FlxG.stage.removeEventListener(openfl.events.MouseEvent.MOUSE_UP, onMouseUp);
-                            FlxG.stage.removeEventListener(openfl.events.MouseEvent.RIGHT_MOUSE_UP, onMouseUp);
-                            _hasOnMouseUp = false;
-                            FlxG.signals.preStateSwitch.remove(onPreStateSwitched);
-                        }
-                    case MouseEvent.MOUSE_MOVE:
-                        if (_hasOnMouseMove == true) {
-                            FlxG.stage.removeEventListener(openfl.events.MouseEvent.MOUSE_MOVE, onMouseMove);
-                            _hasOnMouseMove = false;
-                        }
-                    case MouseEvent.MOUSE_WHEEL:
-                        if (_hasOnMouseWheel == true) {
-                            FlxG.stage.removeEventListener(openfl.events.MouseEvent.MOUSE_WHEEL, onMouseWheel);
-                            _hasOnMouseWheel = false;
-                        }
-                }
             }
         }
     }
     
     private static function onPreStateSwitched() {
         // simulate mouse events when states switch to mop up any visual styles
-        var e = new openfl.events.MouseEvent(openfl.events.MouseEvent.MOUSE_UP);
-        e.stageX = currentMouseX;
-        e.stageY = currentMouseY;
-        e.buttonDown = false;
-        onMouseUp(e);
-
-        var e = new openfl.events.MouseEvent(openfl.events.MouseEvent.MOUSE_MOVE);
-        e.stageX = currentMouseX;
-        e.stageY = currentMouseY;
-        e.buttonDown = false;
-        onMouseMove(e);
+        onMouse(MouseEvent.MOUSE_UP, currentMouseX, currentMouseY);
+        onMouse(MouseEvent.MOUSE_MOVE, currentMouseX, currentMouseY);
     }
     
     private static function onMouseDown(e:openfl.events.MouseEvent) {
-        if (e != null) {
-            currentMouseX = e.stageX;
-            currentMouseY = e.stageY;
+        var type = switch (e.type) {
+            case openfl.events.MouseEvent.MIDDLE_MOUSE_DOWN: MouseEvent.MIDDLE_MOUSE_DOWN;
+            case openfl.events.MouseEvent.RIGHT_MOUSE_DOWN: MouseEvent.RIGHT_MOUSE_DOWN;
+            default: MouseEvent.MOUSE_DOWN;
         }
-        
-        var list = _callbacks.get(MouseEvent.MOUSE_DOWN);
-        if (list == null || list.length == 0) {
-            return;
-        }
-        
-        list = list.copy();
-        
-        var event = new MouseEvent(MouseEvent.MOUSE_DOWN);
-        if (e != null) {
-            event.screenX = (e.stageX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
-            event.screenY = (e.stageY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
-        } else {
-            event.screenX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
-            event.screenY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
-        }
-        if (Platform.instance.isMobile) {
-            event.touchEvent = true;
-        }
-
-        event.data = -1;
-        if (e.type == openfl.events.MouseEvent.MOUSE_DOWN) {
-            event.data = 0;
-        } else if (e.type == openfl.events.MouseEvent.RIGHT_MOUSE_DOWN) {
-            event.data = 1;
-        }
-
-        for (l in list) {
-            l.fn(event);
-            if (event.canceled == true) {
-                break;
-            }
-        }
+        onMouse(type, e.stageX, e.stageY, e.buttonDown, e.ctrlKey, e.shiftKey);
     }
     
     private static function onMouseUp(e:openfl.events.MouseEvent) {
-        if (e != null) {
-            currentMouseX = e.stageX;
-            currentMouseY = e.stageY;
+        var type = switch (e.type) {
+            case openfl.events.MouseEvent.MIDDLE_MOUSE_UP: MouseEvent.MIDDLE_MOUSE_UP;
+            case openfl.events.MouseEvent.RIGHT_MOUSE_UP: MouseEvent.RIGHT_MOUSE_UP;
+            default: MouseEvent.MOUSE_UP;
         }
-        
-        var list = _callbacks.get(MouseEvent.MOUSE_UP);
-        if (list == null || list.length == 0) {
-            return;
-        }
-        
-        list = list.copy();
-        
-        var event = new MouseEvent(MouseEvent.MOUSE_UP);
-        if (e != null) {
-            event.screenX = (e.stageX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
-            event.screenY = (e.stageY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
-        } else {
-            event.screenX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
-            event.screenY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
-        }
-        if (Platform.instance.isMobile) {
-            event.touchEvent = true;
-        }
-
-        event.data = -1;
-        if (e.type == openfl.events.MouseEvent.MOUSE_UP) {
-            event.data = 0;
-        } else if (e.type == openfl.events.MouseEvent.RIGHT_MOUSE_UP) {
-            event.data = 1;
-        }
-
-        for (l in list) {
-            l.fn(event);
-            if (event.canceled == true) {
-                break;
-            }
-        }
+        onMouse(type, e.stageX, e.stageY, e.buttonDown, e.ctrlKey, e.shiftKey);
     }
     
     private static function onMouseMove(e:openfl.events.MouseEvent) {
-        if (e != null) {
-            currentMouseX = e.stageX;
-            currentMouseY = e.stageY;
+        onMouse(MouseEvent.MOUSE_MOVE, e.stageX, e.stageY, e.buttonDown, e.ctrlKey, e.shiftKey);
+    }
+    
+    private static function onMouseWheel(e:openfl.events.MouseEvent) {
+        var event = createEvent(MouseEvent.MOUSE_WHEEL, e.buttonDown, e.ctrlKey, e.shiftKey);
+        event.delta = Math.max(-1, Math.min(1, e.delta));
+
+        var target:Dynamic = getTarget(currentWorldX, currentWorldY);
+
+        dispatchEvent(event, target);
+    }
+
+    private static function onMouse(type:String, x:Float, y:Float, buttonDown:Bool = false, ctrlKey:Bool = false, shiftKey:Bool = false) {
+        if (currentMouseX != x) {
+            currentMouseX = x;
+            currentWorldX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
+        }
+        if (currentMouseY != y) {
+            currentMouseY = y;
+            currentWorldY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
+        }
+
+        var target:Dynamic = getTarget(currentWorldX, currentWorldY);
+
+        var clickType:String = null;
+        switch (type) {
+            case MouseEvent.MOUSE_DOWN:
+                _mouseDownLeft = target;
+
+            case MouseEvent.MIDDLE_MOUSE_DOWN:
+                _mouseDownMiddle = target;
+
+            case MouseEvent.RIGHT_MOUSE_DOWN:
+                _mouseDownRight = target;
+
+            case MouseEvent.MOUSE_UP:
+                if (_mouseDownLeft == target) {
+                    clickType = MouseEvent.CLICK;
+                }
+                _mouseDownLeft = null;
+
+            case MouseEvent.MIDDLE_MOUSE_UP:
+                if (_mouseDownMiddle == target) {
+                    clickType = MouseEvent.MIDDLE_CLICK;
+                }
+                _mouseDownMiddle = null;
+
+            case MouseEvent.RIGHT_MOUSE_UP:
+                if (_mouseDownRight == target) {
+                    clickType = MouseEvent.RIGHT_CLICK;
+                }
+                _mouseDownRight = null;
+        }
+
+        dispatchEventType(type, buttonDown, ctrlKey, shiftKey, target);
+
+        if (clickType != null) {
+            dispatchEventType(clickType, buttonDown, ctrlKey, shiftKey, target);
+            
+            if (type == MouseEvent.MOUSE_UP) {
+                var currentTime = Timer.stamp();
+                if (currentTime - _lastClickTime < 0.5 && target == _lastClickTarget) {
+                    dispatchEventType(MouseEvent.DBL_CLICK, buttonDown, ctrlKey, shiftKey, target);
+                    _lastClickTime = 0;
+                    _lastClickTarget = null;
+                } else {
+                    _lastClickTarget = target;
+                    _lastClickTime = currentTime;
+                }
+            }
+        }
+
+        if (target != _mouseOverTarget) {
+            if (_mouseOverTarget != null) {
+                if ((_mouseOverTarget is Component)) {
+                    Screen.instance.setCursor("default");
+                }
+                dispatchEventType(MouseEvent.MOUSE_OUT, buttonDown, ctrlKey, shiftKey, _mouseOverTarget);
+            }
+            if ((target is Component)) {
+                var c:Component = target;
+                if (c.style != null && c.style.cursor != null) {
+                    Screen.instance.setCursor(c.style.cursor, c.style.cursorOffsetX, c.style.cursorOffsetY);
+                }
+            }
+            dispatchEventType(MouseEvent.MOUSE_OVER, buttonDown, ctrlKey, shiftKey, target);
+            _mouseOverTarget = target;
+        }
+    }
+
+    private static function dispatchEventType(type:String, buttonDown:Bool, ctrlKey:Bool, shiftKey:Bool, target:Dynamic) {
+        var event = createEvent(type, buttonDown, ctrlKey, shiftKey);
+        dispatchEvent(event, target);
+    }
+
+    private static function dispatchEvent(event:MouseEvent, target:Dynamic) {
+        if ((target is Component)) {
+            var c:Component = cast target;
+            // recreate a bubbling effect, so components will pass events onto their parents
+            // can't use the `bubble` property as it causes a crash when `target` isn't the expected result, for example, on ListView.onRendererClick
+            while (c != null) {
+                if (c.hasEvent(event.type)) {
+                    c.dispatch(event);
+                    if (event.canceled == true) {
+                        return;
+                    }
+                }
+                c = c.parentComponent;
+            }
         }
         
-        var list = _callbacks.get(MouseEvent.MOUSE_MOVE);
+        var list = _callbacks.get(event.type);
         if (list == null || list.length == 0) {
             return;
         }
         
         list = list.copy();
-        var event = new MouseEvent(MouseEvent.MOUSE_MOVE);
-        if (e != null) {
-            event.screenX = (e.stageX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
-            event.screenY = (e.stageY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
-        } else {
-            event.screenX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
-            event.screenY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
-        }
-        if (Platform.instance.isMobile) {
-            event.touchEvent = true;
-        }
 
         for (l in list) {
             l.fn(event);
@@ -227,28 +228,26 @@ class MouseHelper {
             }
         }
     }
-    
-    private static function onMouseWheel(e:openfl.events.MouseEvent) {
-        var list = _callbacks.get(MouseEvent.MOUSE_WHEEL);
-        if (list == null || list.length == 0) {
-            return;
+
+    private static function createEvent(type:String, buttonDown:Bool, ctrlKey:Bool, shiftKey:Bool):MouseEvent {
+        var event = new MouseEvent(type);
+        event.screenX = currentWorldX / Toolkit.scaleX;
+        event.screenY = currentWorldY / Toolkit.scaleY;
+        event.buttonDown = buttonDown;
+        event.touchEvent = Platform.instance.isMobile;
+        event.ctrlKey = ctrlKey;
+        event.shiftKey = shiftKey;
+        return event;
+    }
+
+    private static function getTarget(x:Float, y:Float):Dynamic {
+        var target:Dynamic = null;
+        var components = Screen.instance.findComponentsUnderPoint(x, y);
+        if (components.length > 0 && components[components.length - 1].state == StateHelper.currentState) {
+            target = components[components.length - 1];
         }
-        
-        list = list.copy();
-        
-        var event = new MouseEvent(MouseEvent.MOUSE_WHEEL);
-        event.screenX = (e.stageX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
-        event.screenY = (e.stageY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
-        event.delta = Math.max(-1, Math.min(1, e.delta));
-        if (Platform.instance.isMobile) {
-            event.touchEvent = true;
-        }
-        for (l in list) {
-            l.fn(event);
-            if (event.canceled == true) {
-                break;
-            }
-        }
+        if (target == null) target = Screen.instance;
+        return target;
     }
     
     private static inline function initialZoom():Float {

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -103,7 +103,7 @@ class MouseHelper {
     
     private static function onPreStateSwitched() {
         // simulate mouse events when states switch to mop up any visual styles
-        var e = new openfl.events.MouseEvent(openfl.events.MouseEvent.MOUSE_DOWN);
+        var e = new openfl.events.MouseEvent(openfl.events.MouseEvent.MOUSE_UP);
         e.stageX = currentMouseX;
         e.stageY = currentMouseY;
         e.buttonDown = false;


### PR DESCRIPTION
This PR changes the mouse & keyboard event systems to behave more like OpenFL, where the target component (the top-most one for mouse events, or the currently focused one for keyboard events) receives the event first before bubbling up to the parents. This fixes cases of a container receiving an event before its children, even if the user interacted with one of the components inside it.

Other improvements from this PR:
- All mouse event types are now supported by both the screen and components, including double clicks and the middle mouse button
- All mouse events now have `buttonDown`, `touchEvent`, `ctrlKey` and `shiftKey` set correctly
- All events now respond to being canceled
- Mouse wheel events now have `screenX` and `screenY` set
- Event objects are no longer duplicated when dispatching them on listeners, the original one is always used
- Fixed the pre-state switch mouse up event having a MOUSE_DOWN type
- Removed the unused KEY_PRESS event from the supported events list

Before:

https://github.com/haxeui/haxeui-flixel/assets/85134252/753bcf78-e302-429a-ac40-4ea7307f4fa2

After:

https://github.com/haxeui/haxeui-flixel/assets/85134252/ea625b71-e324-4d87-aec9-65b5cef91fcf

