### PR TITLE
Fixed crash from text input not being destroyed

### DIFF
--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -389,6 +389,7 @@ class FlxTextInput extends TextBase {
     public function destroy(component:Component) {
         tf.visible = false;
         component.remove(tf);
+        tf.destroy();
         tf = null;
     }
 }


### PR DESCRIPTION
If you switched to another state while having a text input in focus, the application would crash if you typed something.