### PR TITLE
Fix child components being added to `Screen.instance.rootComponents`

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -88,18 +88,20 @@ class ScreenImpl extends ScreenBase {
     }
 
     private function onMemberAdded(m:FlxBasic) {
-        if ((m is Component) && rootComponents.indexOf(cast(m, Component)) == -1) {
-            var c = cast(m, Component);
-            if (c.percentWidth > 0) {
-                c.width = (this.width * c.percentWidth) / 100;
+        if ((m is Component)) {
+            if (rootComponents.indexOf(cast(m, Component)) == -1) {
+                var c = cast(m, Component);
+                if (c.percentWidth > 0) {
+                    c.width = (this.width * c.percentWidth) / 100;
+                }
+                if (c.percentHeight > 0) {
+                    c.height = (this.height * c.percentHeight) / 100;
+                }
+                c.state = StateHelper.currentState;
+                rootComponents.push(c);
+                c.recursiveReady();
+                c.syncComponentValidation();
             }
-            if (c.percentHeight > 0) {
-                c.height = (this.height * c.percentHeight) / 100;
-            }
-            c.state = StateHelper.currentState;
-            rootComponents.push(c);
-            c.recursiveReady();
-            c.syncComponentValidation();
         } else if ((m is FlxTypedGroup)) {
             var group:FlxTypedGroup<FlxBasic> = cast m;
             checkMembers(group);
@@ -120,19 +122,21 @@ class ScreenImpl extends ScreenBase {
         
         var found = false; // we only want top level components
         for (m in state.members) {
-            if ((m is Component) && rootComponents.indexOf(cast(m, Component)) == -1) {
-                var c = cast(m, Component);
-                if (c.percentWidth > 0) {
-                    c.width = (this.width * c.percentWidth) / 100;
+            if ((m is Component)) {
+                if (rootComponents.indexOf(cast(m, Component)) == -1) {
+                    var c = cast(m, Component);
+                    if (c.percentWidth > 0) {
+                        c.width = (this.width * c.percentWidth) / 100;
+                    }
+                    if (c.percentHeight > 0) {
+                        c.height = (this.height * c.percentHeight) / 100;
+                    }
+                    c.state = StateHelper.currentState;
+                    rootComponents.push(c);
+                    c.recursiveReady();
+                    c.syncComponentValidation();
+                    found = true;
                 }
-                if (c.percentHeight > 0) {
-                    c.height = (this.height * c.percentHeight) / 100;
-                }
-                c.state = StateHelper.currentState;
-                rootComponents.push(c);
-                c.recursiveReady();
-                c.syncComponentValidation();
-                found = true;
             } else if ((m is FlxTypedGroup)) {
                 var group:FlxTypedGroup<FlxBasic> = cast m;
                 group.memberAdded.addOnce(onMemberAdded);


### PR DESCRIPTION
Basically after `FlxG.signals.postStateSwitch` was dispatched, the `checkMembers` function would loop through already-added components and add their children to `rootComponents`. This resulted in a more noticeable bug where components wouldn't lose their focus after you click on empty space, since `topComponent` would return one that wasn't actually on top.

Before:

https://github.com/haxeui/haxeui-flixel/assets/85134252/0eb81ea4-829d-479b-98d1-9194912a826d

After:

https://github.com/haxeui/haxeui-flixel/assets/85134252/aa867fe2-738f-4b27-aa12-2eb326f62258

