### PR TITLE
Normalize screen component addition

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -89,18 +89,9 @@ class ScreenImpl extends ScreenBase {
 
     private function onMemberAdded(m:FlxBasic) {
         if ((m is Component)) {
-            if (rootComponents.indexOf(cast(m, Component)) == -1) {
-                var c = cast(m, Component);
-                if (c.percentWidth > 0) {
-                    c.width = (this.width * c.percentWidth) / 100;
-                }
-                if (c.percentHeight > 0) {
-                    c.height = (this.height * c.percentHeight) / 100;
-                }
-                c.state = StateHelper.currentState;
-                rootComponents.push(c);
-                c.recursiveReady();
-                c.syncComponentValidation();
+            var c = cast(m, Component);
+            if (rootComponents.indexOf(c) == -1) {
+                addComponent(c);
             }
         } else if ((m is FlxTypedGroup)) {
             var group:FlxTypedGroup<FlxBasic> = cast m;
@@ -123,18 +114,9 @@ class ScreenImpl extends ScreenBase {
         var found = false; // we only want top level components
         for (m in state.members) {
             if ((m is Component)) {
-                if (rootComponents.indexOf(cast(m, Component)) == -1) {
-                    var c = cast(m, Component);
-                    if (c.percentWidth > 0) {
-                        c.width = (this.width * c.percentWidth) / 100;
-                    }
-                    if (c.percentHeight > 0) {
-                        c.height = (this.height * c.percentHeight) / 100;
-                    }
-                    c.state = StateHelper.currentState;
-                    rootComponents.push(c);
-                    c.recursiveReady();
-                    c.syncComponentValidation();
+                var c = cast(m, Component);
+                if (rootComponents.indexOf(c) == -1) {
+                    addComponent(c);
                     found = true;
                 }
             } else if ((m is FlxTypedGroup)) {
@@ -220,10 +202,12 @@ class ScreenImpl extends ScreenBase {
 
         if (StateHelper.currentState.exists == true) {
             StateHelper.currentState.add(component);
+            component.state = StateHelper.currentState;
             if (rootComponents.indexOf(component) == -1) {
                 rootComponents.push(component);
             }
             component.recursiveReady();
+            component.syncComponentValidation();
             onContainerResize();
             component.applyAddInternal();
             checkResetCursor();

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -206,9 +206,9 @@ class ScreenImpl extends ScreenBase {
             if (rootComponents.indexOf(component) == -1) {
                 rootComponents.push(component);
             }
+            onContainerResize();
             component.recursiveReady();
             component.syncComponentValidation();
-            onContainerResize();
             component.applyAddInternal();
             checkResetCursor();
         }


### PR DESCRIPTION
This makes the `onMemberAdded()` and `checkMembers()` functions in ScreenImpl use `addComponent()`, instead of having their own separate component addition code. Aside from making it more convenient to change something related to adding components, this fixes a bug where `Screen.instance.setComponentIndex()` would call `removeComponent()` (from listening to `FlxG.state.memberRemoved`) but not `addComponent()` afterwards, creating issues such as `component.hitTest()` always returning false due to `component.hasScreen` being false.