### PR TITLE
Various mouse fixes

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -381,10 +381,10 @@ class ScreenImpl extends ScreenBase {
     @:allow(haxe.ui.backend.flixel.MouseHelper)
     private function checkResetCursor(x:Null<Float> = null, y:Null<Float> = null) {
         if (x == null) {
-            x = MouseHelper.currentMouseX;
+            x = MouseHelper.currentWorldX;
         }
         if (y == null) {
-            y = MouseHelper.currentMouseY;
+            y = MouseHelper.currentWorldY;
         }
         var components = Screen.instance.findComponentsUnderPoint(x, y);
         components.reverse();

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -378,6 +378,7 @@ class ScreenImpl extends ScreenBase {
         return false;
     }
 
+    @:allow(haxe.ui.backend.flixel.MouseHelper)
     private function checkResetCursor(x:Null<Float> = null, y:Null<Float> = null) {
         if (x == null) {
             x = MouseHelper.currentMouseX;
@@ -386,6 +387,7 @@ class ScreenImpl extends ScreenBase {
             y = MouseHelper.currentMouseY;
         }
         var components = Screen.instance.findComponentsUnderPoint(x, y);
+        components.reverse();
         var desiredCursor = "default";
         var desiredCursorOffsetX:Null<Int> = null;
         var desiredCursorOffsetY:Null<Int> = null;

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -128,6 +128,23 @@ class MouseHelper {
 
         var target:Dynamic = getTarget(currentWorldX, currentWorldY);
 
+        if (target != _mouseOverTarget) {
+            if (_mouseOverTarget != null) {
+                if ((_mouseOverTarget is Component)) {
+                    Screen.instance.setCursor("default");
+                }
+                dispatchEventType(MouseEvent.MOUSE_OUT, buttonDown, ctrlKey, shiftKey, _mouseOverTarget);
+            }
+            if ((target is Component)) {
+                var c:Component = target;
+                if (c.style != null && c.style.cursor != null) {
+                    Screen.instance.setCursor(c.style.cursor, c.style.cursorOffsetX, c.style.cursorOffsetY);
+                }
+            }
+            dispatchEventType(MouseEvent.MOUSE_OVER, buttonDown, ctrlKey, shiftKey, target);
+            _mouseOverTarget = target;
+        }
+
         var clickType:String = null;
         switch (type) {
             case MouseEvent.MOUSE_DOWN:
@@ -174,23 +191,6 @@ class MouseHelper {
                     _lastClickTime = currentTime;
                 }
             }
-        }
-
-        if (target != _mouseOverTarget) {
-            if (_mouseOverTarget != null) {
-                if ((_mouseOverTarget is Component)) {
-                    Screen.instance.setCursor("default");
-                }
-                dispatchEventType(MouseEvent.MOUSE_OUT, buttonDown, ctrlKey, shiftKey, _mouseOverTarget);
-            }
-            if ((target is Component)) {
-                var c:Component = target;
-                if (c.style != null && c.style.cursor != null) {
-                    Screen.instance.setCursor(c.style.cursor, c.style.cursorOffsetX, c.style.cursorOffsetY);
-                }
-            }
-            dispatchEventType(MouseEvent.MOUSE_OVER, buttonDown, ctrlKey, shiftKey, target);
-            _mouseOverTarget = target;
         }
     }
 

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -119,11 +119,11 @@ class MouseHelper {
     private static function onMouse(type:String, x:Float, y:Float, buttonDown:Bool = false, ctrlKey:Bool = false, shiftKey:Bool = false) {
         if (currentMouseX != x) {
             currentMouseX = x;
-            currentWorldX = (currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom());
+            currentWorldX = ((currentMouseX - FlxG.scaleMode.offset.x) / (FlxG.scaleMode.scale.x * initialZoom())) / Toolkit.scaleX;
         }
         if (currentMouseY != y) {
             currentMouseY = y;
-            currentWorldY = (currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom());
+            currentWorldY = ((currentMouseY - FlxG.scaleMode.offset.y) / (FlxG.scaleMode.scale.y * initialZoom())) / Toolkit.scaleY;
         }
 
         var target:Dynamic = getTarget(currentWorldX, currentWorldY);
@@ -232,8 +232,8 @@ class MouseHelper {
 
     private static function createEvent(type:String, buttonDown:Bool, ctrlKey:Bool, shiftKey:Bool):MouseEvent {
         var event = new MouseEvent(type);
-        event.screenX = currentWorldX / Toolkit.scaleX;
-        event.screenY = currentWorldY / Toolkit.scaleY;
+        event.screenX = currentWorldX;
+        event.screenY = currentWorldY;
         event.buttonDown = buttonDown;
         event.touchEvent = Platform.instance.isMobile;
         event.ctrlKey = ctrlKey;

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -242,13 +242,41 @@ class MouseHelper {
     }
 
     private static function getTarget(x:Float, y:Float):Dynamic {
-        var target:Dynamic = null;
-        var components = Screen.instance.findComponentsUnderPoint(x, y);
-        if (components.length > 0 && components[components.length - 1].state == StateHelper.currentState) {
-            target = components[components.length - 1];
+        if (Screen.instance.rootComponents.length == 0) {
+            return Screen.instance;
         }
-        if (target == null) target = Screen.instance;
-        return target;
+
+        var i = Screen.instance.rootComponents.length - 1;
+        while (i >= 0) {
+            var c = findDeepestComponentUnderPoint(Screen.instance.rootComponents[i], x, y);
+            if (c != null) {
+                return c;
+            }
+            --i;
+        }
+
+        return Screen.instance;
+    }
+
+    private static function findDeepestComponentUnderPoint(c:Component, x:Float, y:Float):Null<Component>
+    {
+        if (c.state != StateHelper.currentState) {
+            return null;
+        }
+
+        var hit = c.hitTest(x, y);
+        if (c.childComponents.length > 0 && hit) {
+            var i = c.childComponents.length - 1;
+            while (i >= 0) {
+                var ret = findDeepestComponentUnderPoint(c.childComponents[i], x, y);
+                if (ret != null) {
+                    return ret;
+                }
+                --i;
+            }
+        }
+        
+        return hit ? c : null;
     }
     
     private static inline function initialZoom():Float {

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -129,17 +129,9 @@ class MouseHelper {
         var target:Dynamic = getTarget(currentWorldX, currentWorldY);
 
         if (target != _mouseOverTarget) {
+            Screen.instance.checkResetCursor();
             if (_mouseOverTarget != null) {
-                if ((_mouseOverTarget is Component)) {
-                    Screen.instance.setCursor("default");
-                }
                 dispatchEventType(MouseEvent.MOUSE_OUT, buttonDown, ctrlKey, shiftKey, _mouseOverTarget);
-            }
-            if ((target is Component)) {
-                var c:Component = target;
-                if (c.style != null && c.style.cursor != null) {
-                    Screen.instance.setCursor(c.style.cursor, c.style.cursorOffsetX, c.style.cursorOffsetY);
-                }
             }
             dispatchEventType(MouseEvent.MOUSE_OVER, buttonDown, ctrlKey, shiftKey, target);
             _mouseOverTarget = target;

--- a/haxe/ui/backend/flixel/MouseHelper.hx
+++ b/haxe/ui/backend/flixel/MouseHelper.hx
@@ -234,41 +234,14 @@ class MouseHelper {
     }
 
     private static function getTarget(x:Float, y:Float):Dynamic {
-        if (Screen.instance.rootComponents.length == 0) {
-            return Screen.instance;
-        }
-
-        var i = Screen.instance.rootComponents.length - 1;
-        while (i >= 0) {
-            var c = findDeepestComponentUnderPoint(Screen.instance.rootComponents[i], x, y);
-            if (c != null) {
+        var components = Screen.instance.findComponentsUnderPoint(x, y);
+        components.reverse();
+        for (c in components) {
+            if (c.state == StateHelper.currentState) {
                 return c;
             }
-            --i;
         }
-
         return Screen.instance;
-    }
-
-    private static function findDeepestComponentUnderPoint(c:Component, x:Float, y:Float):Null<Component>
-    {
-        if (c.state != StateHelper.currentState) {
-            return null;
-        }
-
-        var hit = c.hitTest(x, y);
-        if (c.childComponents.length > 0 && hit) {
-            var i = c.childComponents.length - 1;
-            while (i >= 0) {
-                var ret = findDeepestComponentUnderPoint(c.childComponents[i], x, y);
-                if (ret != null) {
-                    return ret;
-                }
-                --i;
-            }
-        }
-        
-        return hit ? c : null;
     }
     
     private static inline function initialZoom():Float {


### PR DESCRIPTION
- Fixed `MouseHelper.getTarget()` and `ScreenImpl.checkResetCursor()` not taking `Toolkit.scale` into account
- MOUSE_OUT/MOUSE_OVER events are now dispatched before MOUSE_MOVE events. This is consistent with haxeui-html5, and fixes a bug where windows couldn't be resized if you had your cursor right inside the border
- Fixed cursor changing to default when hovering over a child of a component with a custom cursor
- Slightly rewrote `MouseHelper.getTarget()` and made it iterate through the components instead of only checking the top one
- `ScreenImpl.checkResetCursor()` now iterates backwards through the components, so deeper ones will be checked first