### PR TITLE
Minor fixes

### DIFF
--- a/haxe/ui/backend/ComponentGraphicsImpl.hx
+++ b/haxe/ui/backend/ComponentGraphicsImpl.hx
@@ -20,6 +20,11 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
         var w = Std.int(_component.width);
         var h = Std.int(_component.height);
 
+        if (bitmapData != null && (bitmapData.width != w || bitmapData.height != h)) {
+            bitmapData.dispose();
+            bitmapData = null;
+        }
+
         if (bitmapData == null) {
             bitmapData = new BitmapData(w, h, true, 0x00000000);
         }

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -396,7 +396,11 @@ class ComponentImpl extends ComponentBase {
             getImageDisplay().alpha = value;
         }
         for (c in childComponents) {
-            c.applyAlpha(value);
+            if (c.style != null && c.style.opacity != null) {
+                c.applyAlpha(c.style.opacity * value);
+            } else {
+                c.applyAlpha(value);
+            }
         }
     }
 
@@ -869,7 +873,7 @@ class ComponentImpl extends ComponentBase {
             _unsolicitedMembers = null;
         }
         
-        this.state = null;
+        _state = null;
         _destroy = false;
         _destroyed = true;
         super.destroy();
@@ -890,7 +894,7 @@ class ComponentImpl extends ComponentBase {
     
     private override function set_x(value:Float):Float {
         var r = super.set_x(value);
-        if (this.parentComponent == null) {
+        if (this.parentComponent == null && this.isReady) {
             this.left = value;
         }
         return r;
@@ -898,7 +902,7 @@ class ComponentImpl extends ComponentBase {
     
     private override function set_y(value:Float):Float {
         var r = super.set_y(value);
-        if (this.parentComponent == null) {
+        if (this.parentComponent == null && this.isReady) {
             this.top = value;
         }
         return r;

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -193,6 +193,10 @@ class ScreenImpl extends ScreenBase {
     }
 
     public override function addComponent(component:Component):Component {
+        if (rootComponents.contains(component) && StateHelper.currentState.members.contains(component)) {
+            return component;
+        }
+
         if (rootComponents.length > 0) {
             var cameras = StateHelper.findCameras(rootComponents[0]);
             if (cameras != null) {
@@ -201,11 +205,11 @@ class ScreenImpl extends ScreenBase {
         }
 
         if (StateHelper.currentState.exists == true) {
-            StateHelper.currentState.add(component);
-            component.state = StateHelper.currentState;
             if (rootComponents.indexOf(component) == -1) {
                 rootComponents.push(component);
             }
+            StateHelper.currentState.add(component);
+            component.state = StateHelper.currentState;
             onContainerResize();
             component.recursiveReady();
             component.syncComponentValidation();
@@ -265,11 +269,14 @@ class ScreenImpl extends ScreenBase {
 
     private override function handleSetComponentIndex(child:Component, index:Int) {
         var offset = 0;
-        StateHelper.currentState.forEach((item) -> {
-            offset++;
-        });
+        for (i in 0...StateHelper.currentState.length) {
+            if ((StateHelper.currentState.members[i] is Component)) {
+                offset = i;
+                break;
+            }
+        }
 
-        StateHelper.currentState.remove(child);
+        StateHelper.currentState.remove(child, true);
         StateHelper.currentState.insert(index + offset, child);
     }
 

--- a/haxe/ui/backend/TextDisplayImpl.hx
+++ b/haxe/ui/backend/TextDisplayImpl.hx
@@ -82,10 +82,12 @@ class TextDisplayImpl extends TextBase {
     
     private override function validateDisplay() {
         if (tf.textField.width != _width) {
-            tf.textField.width = _width * Toolkit.scaleX;
+            var width = _width * Toolkit.scaleX;
+            tf.textField.width = (width >= 1 ? width : 1);
         }
         if (tf.textField.height != _height) {
-            tf.textField.height = _height * Toolkit.scaleY;
+            var height = _height * Toolkit.scaleY;
+            tf.textField.height = (height >= 1 ? height : 1);
         }
     }
     


### PR DESCRIPTION
- Fixed crash when a canvas gets resized to be smaller
- Components now set their own `_state` to null instead of their parents' when destroyed (this caused mouse events to stop working entirely)
- Components passing their opacity onto their children will take the child's opacity into account (fixes the dialog modal background being changed to opaque when the parent window was resized)
- `ComponentImpl.set_x()` and `set_y()` will no longer change `left` or `top` if the component isn't ready yet (fixes `Dialog.autoCenterDialog` always starting as false)
- Fixed `ScreenImpl.handleSetComponentIndex()` using a wrong offset (code was changed to match how haxeui-openfl does it)
- Fixed `ScreenImpl.handleSetComponentIndex()` not removing the object entirely before inserting it again
- Prevent `Screen.addComponent()` from being called twice when using it directly due to the `FlxG.state.memberAdded` listener
- Fixed incorrect frame size warning when resizing a text field to 0