### PR TITLE
Reduce update & draw calls

### DIFF
--- a/haxe/ui/backend/ComponentGraphicsImpl.hx
+++ b/haxe/ui/backend/ComponentGraphicsImpl.hx
@@ -48,15 +48,17 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
         var byteArray = ByteArray.fromBytes(newPixels);
         bitmapData.setPixels(new Rectangle(0, 0, bitmapData.width, bitmapData.height), byteArray);
 
-        if (this.sprite == null) {
+        if (sprite == null) {
             sprite = new FlxSprite(0, 0);
+            sprite.active = false;
             _component.add(sprite);            
         }
 
         sprite.width = w;
         sprite.height = h;
 
-        this.sprite.pixels = bitmapData;
+        sprite.pixels = bitmapData;
+        sprite.visible = (w > 0 && h > 0);
     }
 
     public override function resize(width:Null<Float>, height:Null<Float>) {

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -48,7 +48,8 @@ class ComponentImpl extends ComponentBase {
         _surface = new FlxSprite();
         _surface.makeGraphic(1, 1, 0x0, true);
         _surface.pixelPerfectRender = true;
-        _surface.moves = false;
+        _surface.active = false;
+        _surface.visible = false;
         add(_surface);
         
         //recursiveReady();
@@ -228,6 +229,7 @@ class ComponentImpl extends ComponentBase {
             if (w <= 0 || h <= 0) {
                 _surface.graphic.destroy();
                 _surface.makeGraphic(1, 1, 0x0, true);
+                _surface.visible = false;
             } else {
                 _surface.graphic.destroy();
                 _surface.makeGraphic(w, h, 0x0, true);
@@ -357,9 +359,7 @@ class ComponentImpl extends ComponentBase {
         }
 
         for (c in this.childComponents) {
-            if (!c.hidden) {
-                c.applyVisibility(show);
-            }
+            c.applyVisibility(show && !c.hidden);
         }
     }
 
@@ -380,7 +380,7 @@ class ComponentImpl extends ComponentBase {
         }
         */
 
-        FlxStyleHelper.applyStyle(_surface, style);
+        _surface.visible = FlxStyleHelper.applyStyle(_surface, style);
         applyFilters(style);
     }
     

--- a/haxe/ui/backend/ImageDisplayImpl.hx
+++ b/haxe/ui/backend/ImageDisplayImpl.hx
@@ -7,6 +7,7 @@ class ImageDisplayImpl extends ImageBase {
     public function new() {
         super();
         this.pixelPerfectRender = true;
+        this.active = false;
     }
     
     private override function validateData():Void {

--- a/haxe/ui/backend/TextDisplayImpl.hx
+++ b/haxe/ui/backend/TextDisplayImpl.hx
@@ -14,6 +14,7 @@ class TextDisplayImpl extends TextBase {
         tf = new FlxText();
         tf.pixelPerfectRender = true;
         tf.autoSize = true;
+        tf.active = false;
     }
     
     private override function validateData() {

--- a/haxe/ui/backend/flixel/OpenFLStyleHelper.hx
+++ b/haxe/ui/backend/flixel/OpenFLStyleHelper.hx
@@ -12,13 +12,13 @@ class OpenFLStyleHelper {
     public function new() {
     }
 
-    public static function paintStyleSection(graphics:Graphics, style:Style, width:Float, height:Float, left:Float = 0, top:Float = 0, clear:Bool = true) {
+    public static function paintStyleSection(graphics:Graphics, style:Style, width:Float, height:Float, left:Float = 0, top:Float = 0, clear:Bool = true):Bool {
         if (clear == true) {
             graphics.clear();
         }
 
         if (width <= 0 || height <= 0) {
-            return;
+            return false;
         }
 
         /*
@@ -45,6 +45,8 @@ class OpenFLStyleHelper {
             borderRadius = style.borderRadius * Toolkit.scale;
         }
 
+        var painted = false;
+
         if (style.borderLeftSize != null && style.borderLeftSize != 0
             && style.borderLeftSize == style.borderRightSize
             && style.borderLeftSize == style.borderBottomSize
@@ -61,6 +63,8 @@ class OpenFLStyleHelper {
             rc.bottom -= (style.borderLeftSize * Toolkit.scale) / 2;
             rc.right -= (style.borderLeftSize * Toolkit.scale) / 2;
             //rc.inflate( -(style.borderLeftSize / 2), -(style.borderLeftSize / 2));
+
+            painted = true;
         } else { // compound border
             if ((style.borderTopSize != null && style.borderTopSize > 0)
                 || (style.borderBottomSize != null && style.borderBottomSize > 0)
@@ -100,6 +104,8 @@ class OpenFLStyleHelper {
 
                         rc.right -= (style.borderRightSize * Toolkit.scale);
                     }
+
+                    painted = true;
             }
         }
 
@@ -147,6 +153,10 @@ class OpenFLStyleHelper {
             } else {
                 graphics.beginFill(backgroundColor, backgroundOpacity);
             }
+
+            if (backgroundOpacity > 0) {
+                painted = true;
+            }
         }
 
         if (borderRadius == 0) {
@@ -165,5 +175,7 @@ class OpenFLStyleHelper {
         }
 
         graphics.endFill();
+
+        return painted;
     }
 }

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -44,7 +44,7 @@ class FlxTextInput extends TextBase {
         return tf.visible;
     }
     private function set_visible(value:Bool):Bool {
-        tf.visible = value;
+        tf.active = tf.visible = value; // text input shouldn't be active if it's hidden
         return value;
     }
 


### PR DESCRIPTION
- All sprites except text inputs are now always inactive, skipping their update calls
- `ComponentImpl._surface` will be invisible if the style doesn't have anything to display, skipping a draw call
- `ComponentGraphicsImpl.sprite` will be invisible if the width or height are 0
- `FlxTextInput.visible` now also changes the `active` property to prevent unnecessary update calls
- `ComponentImpl.applyVisibility()` is now called properly to prevent unnecessary text input update calls