### PR TITLE
Fix resized images not being clipped correctly

### DIFF
--- a/haxe/ui/backend/ImageDisplayImpl.hx
+++ b/haxe/ui/backend/ImageDisplayImpl.hx
@@ -1,6 +1,7 @@
 package haxe.ui.backend;
 
 import flixel.graphics.frames.FlxImageFrame;
+import flixel.math.FlxRect;
 import haxe.ui.Toolkit;
 
 class ImageDisplayImpl extends ImageBase {
@@ -15,16 +16,25 @@ class ImageDisplayImpl extends ImageBase {
             frames = FlxImageFrame.fromFrame(_imageInfo.data);
             
             aspectRatio = _imageInfo.width / _imageInfo.height;
-            
-            width = frameWidth = Std.int(_imageInfo.width * Toolkit.scaleX);
-            height = frameHeight = Std.int(_imageInfo.height *  Toolkit.scaleY);
+
+            origin.set(0, 0);
         }
     }
     
     private override function validateDisplay() {
         var scaleX:Float = _imageWidth / (_imageInfo.width / Toolkit.scaleX);
         var scaleY:Float = _imageHeight / (_imageInfo.height / Toolkit.scaleY);
-        origin.set(0, 0);
         scale.set(scaleX, scaleY);
+
+        width = Math.abs(scaleX) * frameWidth;
+        height = Math.abs(scaleY) * frameHeight;
+    }
+
+    override function set_clipRect(rect:FlxRect):FlxRect {
+        if (rect != null) {
+            return super.set_clipRect(FlxRect.get(rect.x / scale.x, rect.y / scale.y, rect.width / scale.x, rect.height / scale.y));
+        } else {
+            return super.set_clipRect(null);
+        }
     }
 }


### PR DESCRIPTION
- Resized images (smaller/larger than the original graphic) are now clipped correctly
- `width` and `height` are now set properly for resized image displays, this makes the debug hitboxes show around the actual displayed image
- Prevent unnecessary `origin` resets (only needed when the frames change)

Note: the last 2 changes aren't needed for the clipping problem, but I figured to throw them into this PR.

After the changes:

https://github.com/haxeui/haxeui-flixel/assets/85134252/df77edb3-78a5-4a58-947a-2350964cbff7

