### PR TITLE
Implement an error macro for UI states

### DIFF
--- a/haxe/ui/backend/flixel/UIState.hx
+++ b/haxe/ui/backend/flixel/UIState.hx
@@ -7,6 +7,7 @@ import haxe.ui.events.UIEvent;
 
 @:autoBuild(haxe.ui.macros.Macros.buildBehaviours())
 @:autoBuild(haxe.ui.macros.Macros.build())
+@:autoBuild(haxe.ui.backend.flixel.macros.UIStateMacro.checkDefine())
 class UIState extends UIStateBase { // must use -D haxeui_dont_impose_base_class
     public var bindingRoot:Bool = false;
 

--- a/haxe/ui/backend/flixel/UISubState.hx
+++ b/haxe/ui/backend/flixel/UISubState.hx
@@ -7,6 +7,7 @@ import haxe.ui.events.UIEvent;
 
 @:autoBuild(haxe.ui.macros.Macros.buildBehaviours())
 @:autoBuild(haxe.ui.macros.Macros.build())
+@:autoBuild(haxe.ui.backend.flixel.macros.UIStateMacro.checkDefine())
 class UISubState extends UISubStateBase { // must use -D haxeui_dont_impose_base_class
     public var bindingRoot:Bool = false;
 

--- a/haxe/ui/backend/flixel/macros/UIStateMacro.hx
+++ b/haxe/ui/backend/flixel/macros/UIStateMacro.hx
@@ -1,0 +1,42 @@
+package haxe.ui.backend.flixel.macros;
+
+#if macro
+import haxe.macro.Expr.Field;
+import haxe.macro.Context;
+
+/**
+ * Macro which makes an error at compile time if the user attemps to use `UIState` or `UISubState` without having `haxeui_dont_impose_base_class` defined.
+ */
+class UIStateMacro {
+    public static function checkDefine():Array<Field> {
+        var localClass:String = Context.getLocalClass().get().name;
+
+        if (!Context.defined("haxeui_dont_impose_base_class"))
+            Context.error("You must define haxeui_dont_impose_base_class in order to use " + findUIClass() + " (for class " + localClass + ")", Context.currentPos());
+
+        return Context.getBuildFields();
+    }
+
+    static function findUIClass():String {
+        var cls = Context.getLocalClass().get();
+
+        while (!isUIState(cls.name)) {
+            if (cls.superClass == null)
+                break;
+
+            cls = cls.superClass.t.get();
+        }
+
+        if (!isUIState(cls.name)) {
+            // shouldn't happen, but just in case
+            return "UI states";
+        }
+
+        return cls.name;
+    }
+
+    static function isUIState(name:String):Bool {
+        return name == "UIState" || name == "UISubState";
+    }
+}
+#end


### PR DESCRIPTION
Since those needs `haxeui_dont_impose_base_class` defined, an error that may seem unrelated to the user will happens if this is not defined. This macro replaces the error with a much more easier to understand error.