### PR TITLE
Fix components not being spliced from the state when removed

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -233,13 +233,16 @@ class ScreenImpl extends ScreenBase {
         if (rootComponents.indexOf(component) != -1) {
             throw "component wasnt actually removed from array, or there is a duplicate in the array";
         }
+        if (StateHelper.currentState.exists == true) {
+            StateHelper.currentState.remove(component, true);
+        }
+        // Destroying a sprite makes it get removed from its container (in this case, the state) without
+        // being spliced, causing issues later with `addComponent()` not actually adding components on top
+        // of everything else, so this has to go after the component has been properly removed.
         if (dispose) {
             component.disposeComponent();
         } else {
             component.applyRemoveInternal();
-        }
-        if (StateHelper.currentState.exists == true) {
-            StateHelper.currentState.remove(component, true);
         }
         checkResetCursor();
         onContainerResize();


### PR DESCRIPTION
This fixes a bug where `Screen.instance.addComponent()` sometimes wouldn't add the component on top of everything else, instead inserting it at the first `null` member in the state, which was caused by components (e.g. a dialog) being removed without splicing them from the members array.