### PR TITLE
[BUGFIX/ENHANCEMENT] Use frame Resolution instead of parent resolution.

### DIFF
--- a/haxe/ui/backend/AssetsImpl.hx
+++ b/haxe/ui/backend/AssetsImpl.hx
@@ -93,8 +93,8 @@ class AssetsImpl extends AssetsBase {
     public override function imageInfoFromImageData(imageData:ImageData):ImageInfo {
         return {
             data: imageData,
-            width: imageData.parent.width,
-            height: imageData.parent.height
+            width: imageData.frame.width,
+            height: imageData.frame.height
         }
     }
     


### PR DESCRIPTION
When trying to load a FlxFrame from an atlas, ImageInfo won't use the frame resolution, it will use the parent/atlas resolution. This PR changes that.

Instead, this PR makes `imageInfoFromImageData` return `frame.width`/`frame.height`.

As `Image` will only render things inside the frame, this should not arise any issues.
