### PR TITLE
Fix compilation error caused by the last merged PR

### DIFF
--- a/haxe/ui/backend/AssetsImpl.hx
+++ b/haxe/ui/backend/AssetsImpl.hx
@@ -93,8 +93,8 @@ class AssetsImpl extends AssetsBase {
     public override function imageInfoFromImageData(imageData:ImageData):ImageInfo {
         return {
             data: imageData,
-            width: imageData.frame.width,
-            height: imageData.frame.height
+            width: Std.int(imageData.frame.width),
+            height: Std.int(imageData.frame.height)
         }
     }
     


### PR DESCRIPTION
`ImageInfo` explictly asks for integers width and height. It seems the [latest pull request](https://github.com/haxeui/haxeui-flixel/pull/53) has not been tested and causes a type error at compile time because it passes float values. This PR fixes it by "converting" the float values into integers (I don't think these variables ever gets set to a number with decimal precision?).
There shouldn't be any accuracy loss when the frame is rendered as I doubt sub-pixels matters much (or even gets rendered).