### PR TITLE
Implement core text input from Flixel 5.9.0

### DIFF
--- a/haxe/ui/backend/TextInputImpl.hx
+++ b/haxe/ui/backend/TextInputImpl.hx
@@ -2,12 +2,8 @@ package haxe.ui.backend;
 
 typedef TextInputEvent = {type:String, stageX:Float, stageY:Float};
 
-#if flixel_text_input
-
+#if (flixel >= "5.9.0")
 typedef TextInputImpl = haxe.ui.backend.flixel.textinputs.FlxTextInput;
-
 #else
-
 typedef TextInputImpl = haxe.ui.backend.flixel.textinputs.OpenFLTextInput;
-
 #end

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -200,7 +200,7 @@ class FlxTextInput extends TextBase {
 
     private override function validatePosition() {
         _left = Math.round(_left * Toolkit.scaleX);
-        _top = Math.round(_top * Toolkit.scaleY) + (PADDING_Y / 2);
+        _top = Math.round(_top * Toolkit.scaleY);
     }
 
     private override function validateDisplay() {

--- a/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
+++ b/haxe/ui/backend/flixel/textinputs/FlxTextInput.hx
@@ -1,13 +1,14 @@
 package haxe.ui.backend.flixel.textinputs;
 
 import flixel.FlxSprite;
+import flixel.text.FlxInputText;
+import flixel.util.FlxColor;
 import haxe.ui.backend.TextInputImpl.TextInputEvent;
 import haxe.ui.core.Component;
 import openfl.events.Event;
 import openfl.events.KeyboardEvent;
 
-#if flixel_text_input
-
+#if (flixel >= "5.9.0")
 class FlxTextInput extends TextBase {
     public static var USE_ON_ADDED:Bool = false;
     public static var USE_ON_REMOVED:Bool = false;
@@ -15,25 +16,24 @@ class FlxTextInput extends TextBase {
     private var PADDING_X:Int = 4;
     private var PADDING_Y:Int = 0;
 
-    private var tf:flixel.addons.text.FlxTextInput;
+    private var tf:FlxInputText;
 
     public function new() {
         super();
-        tf = new flixel.addons.text.FlxTextInput();
-        tf.onChange.add(onInternalChange);
-        tf.onScroll.add(onScroll);
+        tf = new FlxInputText(0, 0, 0, null, 8, FlxColor.BLACK, FlxColor.TRANSPARENT);
+        tf.onTextChange.add(onInternalChange);
+        tf.onScrollChange.add(onScroll);
         tf.pixelPerfectRender = true;
-        tf.moves = false;
         _inputData.vscrollPageStep = 1;
         _inputData.vscrollNativeWheel = true;
     }
 
     public override function focus() {
-        tf.focus = true;
+        tf.startFocus();
     }
     
     public override function blur() {
-        tf.focus = false;
+        tf.endFocus();
     }
 
     public function attach() {
@@ -184,14 +184,16 @@ class FlxTextInput extends TextBase {
 
         if (tf.multiline != _displayData.multiline) {
             tf.multiline = _displayData.multiline;
+            // `multiline` only decides whether the user can add new lines,
+            // so measuring the text is not required.
+        }
+
+        if (tf.passwordMode != _inputData.password) {
+            tf.passwordMode = _inputData.password;
             measureTextRequired = true;
         }
 
-        if (tf.displayAsPassword != _inputData.password) {
-            tf.displayAsPassword = _inputData.password;
-        }
-
-        tf.type = (parentComponent.disabled ? DYNAMIC : INPUT);
+        tf.editable = !parentComponent.disabled;
 
         return measureTextRequired;
     }
@@ -300,16 +302,16 @@ class FlxTextInput extends TextBase {
     public var onChange(null, set):TextInputEvent->Void;
     private function set_onChange(value:TextInputEvent->Void):TextInputEvent->Void {
         if (_onChange != null) {
-            tf.onChange.remove(__onTextInputChangeEvent);
+            tf.onTextChange.remove(__onTextInputChangeEvent);
         }
         _onChange = value;
         if (_onChange != null) {
-            tf.onChange.add(__onTextInputChangeEvent);
+            tf.onTextChange.add(__onTextInputChangeEvent);
         }
         return value;
     }
 
-    private function __onTextInputChangeEvent() {
+    private function __onTextInputChangeEvent(text:String, action:FlxInputTextChange) {
         if (_onChange != null) {
             _onChange({
                 type: "change",
@@ -359,7 +361,7 @@ class FlxTextInput extends TextBase {
     }
     */
 
-    private function onInternalChange() {
+    private function onInternalChange(text:String, action:FlxInputTextChange) {
         _text = tf.text;
         
         measureText();
@@ -368,8 +370,8 @@ class FlxTextInput extends TextBase {
             _inputData.onChangedCallback();
         }
     }
-    
-    private function onScroll() {
+
+    private function onScroll(scrollH:Int, scrollV:Int) {
         _inputData.hscrollPos = tf.scrollH;
         _inputData.vscrollPos = tf.scrollV - 1;
         
@@ -388,10 +390,9 @@ class FlxTextInput extends TextBase {
 
     public function destroy(component:Component) {
         tf.visible = false;
-        component.remove(tf);
+        component.remove(tf, true);
         tf.destroy();
         tf = null;
     }
 }
-
 #end


### PR DESCRIPTION
This replaces the FlxTextInput using my old "flixel-text-input" library with the new one included in the base HaxeFlixel since 5.9.0.

(If an older version of HaxeFlixel is being used, it will just default to the OpenFL text input.)