### PR TITLE
Replace FlxGroups with FlxContainers

### DIFF
--- a/haxe/ui/backend/ComponentSurface.hx
+++ b/haxe/ui/backend/ComponentSurface.hx
@@ -1,3 +1,3 @@
 package haxe.ui.backend;
 
-typedef ComponentSurface = flixel.group.FlxSpriteGroup;
+typedef ComponentSurface = flixel.group.FlxSpriteContainer;

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -4,7 +4,7 @@ import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.group.FlxGroup;
-import flixel.group.FlxSpriteContainer;
+import flixel.group.FlxSpriteGroup;
 import haxe.ui.Toolkit;
 import haxe.ui.backend.flixel.CursorHelper;
 import haxe.ui.backend.flixel.KeyboardHelper;
@@ -126,8 +126,8 @@ class ScreenImpl extends ScreenBase {
                     found = true;
                     break;
                 }
-            } else if ((m is FlxTypedSpriteContainer)) {
-                var spriteGroup:FlxTypedSpriteContainer<FlxSprite> = cast m;
+            } else if ((m is FlxTypedSpriteGroup)) {
+                var spriteGroup:FlxTypedSpriteGroup<FlxSprite> = cast m;
                 spriteGroup.group.memberAdded.addOnce(onMemberAdded);
                 if (checkMembers(cast spriteGroup.group) == true) {
                     found = true;
@@ -364,12 +364,12 @@ class ScreenImpl extends ScreenBase {
                         }
                     }
                 }
-                var spriteGroup:FlxTypedSpriteContainer<FlxSprite> = cast m;
+                var spriteGroup:FlxTypedSpriteGroup<FlxSprite> = cast m;
                 if (containsUnsolicitedMemberAt(x, y, cast spriteGroup.group) == true) {
                     return true;
                 }
-            } else if ((m is FlxTypedSpriteContainer)) {
-                var spriteGroup:FlxTypedSpriteContainer<FlxSprite> = cast m;
+            } else if ((m is FlxTypedSpriteGroup)) {
+                var spriteGroup:FlxTypedSpriteGroup<FlxSprite> = cast m;
                 if (!spriteGroup.visible) {
                     continue;
                 }

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -3,7 +3,7 @@ package haxe.ui.backend;
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxSprite;
-import flixel.group.FlxContainer;
+import flixel.group.FlxGroup;
 import flixel.group.FlxSpriteContainer;
 import haxe.ui.Toolkit;
 import haxe.ui.backend.flixel.CursorHelper;
@@ -93,8 +93,8 @@ class ScreenImpl extends ScreenBase {
             if (rootComponents.indexOf(c) == -1) {
                 addComponent(c);
             }
-        } else if ((m is FlxTypedContainer)) {
-            var group:FlxTypedContainer<FlxBasic> = cast m;
+        } else if ((m is FlxTypedGroup)) {
+            var group:FlxTypedGroup<FlxBasic> = cast m;
             checkMembers(group);
         }
     }
@@ -106,7 +106,7 @@ class ScreenImpl extends ScreenBase {
         }
     }
 
-    private function checkMembers(state:FlxTypedContainer<FlxBasic>) {
+    private function checkMembers(state:FlxTypedGroup<FlxBasic>) {
         if (state == null || !state.exists) {
             return false;
         }
@@ -119,8 +119,8 @@ class ScreenImpl extends ScreenBase {
                     addComponent(c);
                     found = true;
                 }
-            } else if ((m is FlxTypedContainer)) {
-                var group:FlxTypedContainer<FlxBasic> = cast m;
+            } else if ((m is FlxTypedGroup)) {
+                var group:FlxTypedGroup<FlxBasic> = cast m;
                 group.memberAdded.addOnce(onMemberAdded);
                 if (checkMembers(group) == true) {
                     found = true;
@@ -339,7 +339,7 @@ class ScreenImpl extends ScreenBase {
         }
     }
 
-    private function containsUnsolicitedMemberAt(x:Float, y:Float, state:FlxTypedContainer<FlxBasic>):Bool {
+    private function containsUnsolicitedMemberAt(x:Float, y:Float, state:FlxTypedGroup<FlxBasic>):Bool {
         if (state == null || !state.exists) {
             return false;
         }

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -3,8 +3,8 @@ package haxe.ui.backend;
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxSprite;
-import flixel.group.FlxGroup.FlxTypedGroup;
-import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
+import flixel.group.FlxContainer;
+import flixel.group.FlxSpriteContainer;
 import haxe.ui.Toolkit;
 import haxe.ui.backend.flixel.CursorHelper;
 import haxe.ui.backend.flixel.KeyboardHelper;
@@ -93,8 +93,8 @@ class ScreenImpl extends ScreenBase {
             if (rootComponents.indexOf(c) == -1) {
                 addComponent(c);
             }
-        } else if ((m is FlxTypedGroup)) {
-            var group:FlxTypedGroup<FlxBasic> = cast m;
+        } else if ((m is FlxTypedContainer)) {
+            var group:FlxTypedContainer<FlxBasic> = cast m;
             checkMembers(group);
         }
     }
@@ -106,7 +106,7 @@ class ScreenImpl extends ScreenBase {
         }
     }
 
-    private function checkMembers(state:FlxTypedGroup<FlxBasic>) {
+    private function checkMembers(state:FlxTypedContainer<FlxBasic>) {
         if (state == null || !state.exists) {
             return false;
         }
@@ -119,15 +119,15 @@ class ScreenImpl extends ScreenBase {
                     addComponent(c);
                     found = true;
                 }
-            } else if ((m is FlxTypedGroup)) {
-                var group:FlxTypedGroup<FlxBasic> = cast m;
+            } else if ((m is FlxTypedContainer)) {
+                var group:FlxTypedContainer<FlxBasic> = cast m;
                 group.memberAdded.addOnce(onMemberAdded);
                 if (checkMembers(group) == true) {
                     found = true;
                     break;
                 }
-            } else if ((m is FlxTypedSpriteGroup)) {
-                var spriteGroup:FlxTypedSpriteGroup<FlxSprite> = cast m;
+            } else if ((m is FlxTypedSpriteContainer)) {
+                var spriteGroup:FlxTypedSpriteContainer<FlxSprite> = cast m;
                 spriteGroup.group.memberAdded.addOnce(onMemberAdded);
                 if (checkMembers(cast spriteGroup.group) == true) {
                     found = true;
@@ -339,7 +339,7 @@ class ScreenImpl extends ScreenBase {
         }
     }
 
-    private function containsUnsolicitedMemberAt(x:Float, y:Float, state:FlxTypedGroup<FlxBasic>):Bool {
+    private function containsUnsolicitedMemberAt(x:Float, y:Float, state:FlxTypedContainer<FlxBasic>):Bool {
         if (state == null || !state.exists) {
             return false;
         }
@@ -364,12 +364,12 @@ class ScreenImpl extends ScreenBase {
                         }
                     }
                 }
-                var spriteGroup:FlxTypedSpriteGroup<FlxSprite> = cast m;
+                var spriteGroup:FlxTypedSpriteContainer<FlxSprite> = cast m;
                 if (containsUnsolicitedMemberAt(x, y, cast spriteGroup.group) == true) {
                     return true;
                 }
-            } else if ((m is FlxTypedSpriteGroup)) {
-                var spriteGroup:FlxTypedSpriteGroup<FlxSprite> = cast m;
+            } else if ((m is FlxTypedSpriteContainer)) {
+                var spriteGroup:FlxTypedSpriteContainer<FlxSprite> = cast m;
                 if (!spriteGroup.visible) {
                     continue;
                 }

--- a/haxe/ui/backend/flixel/UIFragmentBase.hx
+++ b/haxe/ui/backend/flixel/UIFragmentBase.hx
@@ -1,3 +1,3 @@
 package haxe.ui.backend.flixel;
 
-typedef UIFragmentBase = flixel.group.FlxSpriteGroup;
+typedef UIFragmentBase = flixel.group.FlxSpriteContainer;


### PR DESCRIPTION
The following is copied from [this PR](https://github.com/HaxeFlixel/flixel/pull/3050):

> A `FlxContainer` is a `FlxGroup` that removes it's members from their previous container, when added. This means a `FlxBasic` can only ever be in one container at a time. The main benefits  is that it ensures a `FlxBasic` is only in the draw-tree once, unlike `FlxGroups` which can cause sprites to be drawn or updated twice per frame. The rule of thumb is: FlxGroups are for organizing (e.g. for collision or iterating) where Containers are for drawing and updating
> 
> The long term goal of containers is to replace `FlxSpriteGroup` and `FlxNestedSprite` with a system closer to Flash's DisplayObjectContainer tree, where object's x and y may refer to it's local position in the parent, but the global position may be calculated at any time by iterating up the "parents" until reaching the state. Many flixel features currently can only truly know where a sprite will *actually* be drawn while in the draw() phase, especially when there are multiple cameras with different zooms.

The main benefit of this change is that flixel objects added to containers have a reference to their container, and container's properties. This is useful on it's own, particularly for features I'm working on in a project, but fixes a lot of rendering issues. Previously there were issues when UI elements were not on the main camera, since sprites with null cameras draw to their parent's cameras, and there was no way to know which camera that would be unless you were in that sprite's draw() call