### PR TITLE
Exclude code using `FlxG.mouse` from compilation if FLX_NO_MOUSE is defined

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -169,9 +169,9 @@ class ScreenImpl extends ScreenBase {
 
     private var _cursor:String = null;
     public function setCursor(cursor:String, offsetX:Null<Int> = null, offsetY:Null<Int> = null) {
-        #if haxeui_flixel_no_custom_cursors
+        #if (haxeui_flixel_no_custom_cursors || FLX_NO_MOUSE)
         return;
-        #end
+        #else
 
         if (!CursorHelper.useCustomCursors) {
             return;
@@ -190,6 +190,7 @@ class ScreenImpl extends ScreenBase {
         } else {
             FlxG.mouse.load(null);
         }
+        #end
     }
 
     public override function addComponent(component:Component):Component {


### PR DESCRIPTION
When I try to compile a flixel (version 6.0.0) project for android, I get a compile error like this: 
```bash
 ERROR  ~/Desktop/flixel_stuff/haxeui-flixel/haxe/ui/backend/ScreenImpl.hx:187: characters 18-23

 187 |             FlxG.mouse.load(CursorHelper.mouseLoadFunction(cursorInfo.graphic), cursorInfo.scale, cursorInfo.offsetX, cursorInfo.offsetY);
     |                  ^^^^^
     | Class<flixel.FlxG> has no field mouse

      ->  export/android/haxe/ApplicationMain.hx:153: characters 5-36

      153 |     ApplicationMain.getEntryPoint();
          |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          | Called from macro here

      ->  ~/Desktop/flixel_stuff/haxeui-core/haxe/ui/Toolkit.hx:61: characters 9-38

       61 |         ModuleMacros.processModules();
          |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          | Called from macro here

           ->  export/android/haxe/ApplicationMain.hx:153: characters 5-36

           153 |     ApplicationMain.getEntryPoint();
               |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               | Called from macro here
```
It seems to happen due to ScreenImpl.hx using `FlxG.mouse` even if `FLX_NO_MOUSE` is defined. This PR should fix that